### PR TITLE
Utf8 conversions

### DIFF
--- a/src/ImGui.NET.SampleProgram/SampleWindow.cs
+++ b/src/ImGui.NET.SampleProgram/SampleWindow.cs
@@ -50,8 +50,6 @@ namespace ImGuiNET
             _nativeWindow.KeyUp += OnKeyUp;
             _nativeWindow.KeyPress += OnKeyPress;
 
-            ImGui.GetIO().FontAtlas.AddDefaultFont();
-
             SetOpenTKKeyMappings();
 
             _textInputBufferLength = 1024;
@@ -125,6 +123,16 @@ namespace ImGuiNET
         private unsafe void CreateDeviceObjects()
         {
             IO io = ImGui.GetIO();
+
+            // Example: select custom font and glyph range through enum to support non-latin characters
+            ushort[] glyphRangeLatinExtended = new ushort[]
+             {
+                 0x0020, 0x00FF, // Basic Latin + Latin Supplement
+                 0x0100, 0x017F, // Latin Extended-A
+                 0
+            };
+            io.FontAtlas.AddDefaultFont();
+            //io.FontAtlas.AddFontFromFileTTF(@"LiberationMono-Regular.ttf", 14, glyphRangeLatinExtended);
 
             // Build texture atlas
             FontTextureData texData = io.FontAtlas.GetTexDataAsAlpha8();

--- a/src/ImGui.NET/IO.cs
+++ b/src/ImGui.NET/IO.cs
@@ -219,6 +219,8 @@ namespace ImGuiNET
             _atlasPtr = atlasPtr;
         }
 
+        public NativeFontAtlas* GetNativePointer() => _atlasPtr;
+
         public FontTextureData GetTexDataAsAlpha8()
         {
             byte* pixels;
@@ -268,6 +270,21 @@ namespace ImGuiNET
         public Font AddFontFromFileTTF(string fileName, float pixelSize)
         {
             NativeFont* nativeFontPtr = ImGuiNative.ImFontAtlas_AddFontFromFileTTF(_atlasPtr, fileName, pixelSize, IntPtr.Zero, null);
+            return new Font(nativeFontPtr);
+        }
+
+        public Font AddFontFromFileTTF(string fileName, float pixelSize, ushort[] glyphRanges)
+        {
+            fixed (ushort* ptrBuf = glyphRanges)
+            {
+                NativeFont* nativeFontPtr = ImGuiNative.ImFontAtlas_AddFontFromFileTTF(_atlasPtr, fileName, pixelSize, IntPtr.Zero, ptrBuf);
+                return new Font(nativeFontPtr);
+            }
+        }
+
+        public Font AddFontFromFileTTF(string fileName, float pixelSize, ushort* glyphRanges)
+        {
+            NativeFont* nativeFontPtr = ImGuiNative.ImFontAtlas_AddFontFromFileTTF(_atlasPtr, fileName, pixelSize, IntPtr.Zero, glyphRanges);
             return new Font(nativeFontPtr);
         }
 

--- a/src/ImGui.NET/ImGui.cs
+++ b/src/ImGui.NET/ImGui.cs
@@ -7,6 +7,8 @@ namespace ImGuiNET
 {
     public static class ImGui
     {
+        private static Utf8Buffer _utf8 = new Utf8Buffer();
+
         public static void NewFrame()
         {
             ImGuiNative.igNewFrame();
@@ -73,37 +75,34 @@ namespace ImGuiNET
             return ImGuiNative.igGetIDStrRange(idBegin, idEnd);
         }
 
-        public static void Text(string message)
+        public static unsafe void Text(string message)
         {
-            ImGuiNative.igText(message);
+            ImGuiNative.igText(_utf8.FromStr(message));
         }
 
-        public static void Text(string message, Vector4 color)
+        public static unsafe void Text(string message, Vector4 color)
         {
-            ImGuiNative.igTextColored(color, message);
+            ImGuiNative.igTextColored(color, _utf8.FromStr(message));
         }
 
-        public static void TextDisabled(string text)
+        public static unsafe void TextDisabled(string text)
         {
-            ImGuiNative.igTextDisabled(text);
+            ImGuiNative.igTextDisabled(_utf8.FromStr(text));
         }
 
-        public static void TextWrapped(string text)
+        public static unsafe void TextWrapped(string text)
         {
-            ImGuiNative.igTextWrapped(text);
+            ImGuiNative.igTextWrapped(_utf8.FromStr(text));
         }
 
         public static unsafe void TextUnformatted(string message)
         {
-            fixed (byte* bytes = System.Text.Encoding.UTF8.GetBytes(message))
-            {
-                ImGuiNative.igTextUnformatted(bytes, null);
-            }
+            ImGuiNative.igTextUnformatted(_utf8.FromStr(message), null);
         }
-
-        public static void LabelText(string label, string text)
+    
+        public static unsafe void LabelText(string label, string text)
         {
-            ImGuiNative.igLabelText(label, text);
+            ImGuiNative.igLabelText(_utf8.FromStr(label), _utf8.FromStr(text));
         }
 
         public static void Bullet()
@@ -111,9 +110,9 @@ namespace ImGuiNET
             ImGuiNative.igBullet();
         }
 
-        public static void BulletText(string text)
+        public static unsafe void BulletText(string text)
         {
-            ImGuiNative.igBulletText(text);
+            ImGuiNative.igBulletText(_utf8.FromStr(text));
         }
 
         public static bool InvisibleButton(string id) => InvisibleButton(id, Vector2.Zero);
@@ -141,60 +140,61 @@ namespace ImGuiNET
         }
 
         //obsolete!
-        public static bool CollapsingHeader(string label, string id, bool displayFrame, bool defaultOpen)
+        public static unsafe bool CollapsingHeader(string label, string id, bool displayFrame, bool defaultOpen)
         {
             TreeNodeFlags default_open_flags = TreeNodeFlags.DefaultOpen;
-            return ImGuiNative.igCollapsingHeader(label, (defaultOpen ? default_open_flags : 0));
+            return ImGuiNative.igCollapsingHeader(_utf8.FromStr(label), (defaultOpen ? default_open_flags : 0));
         }
 
-
-        public static bool CollapsingHeader(string label, TreeNodeFlags flags)
+        public static unsafe bool CollapsingHeader(string label, TreeNodeFlags flags)
         {
-            return ImGuiNative.igCollapsingHeader(label, flags);
+            return ImGuiNative.igCollapsingHeader(_utf8.FromStr(label), flags);
         }
 
-        public static bool Checkbox(string label, ref bool value)
+        public static unsafe bool Checkbox(string label, ref bool value)
         {
-            return ImGuiNative.igCheckbox(label, ref value);
+            return ImGuiNative.igCheckbox(_utf8.FromStr(label), ref value);
         }
 
         public static unsafe bool RadioButton(string label, ref int target, int buttonValue)
         {
             int targetCopy = target;
-            bool result = ImGuiNative.igRadioButton(label, &targetCopy, buttonValue);
+            bool result = ImGuiNative.igRadioButton(_utf8.FromStr(label), &targetCopy, buttonValue);
             target = targetCopy;
             return result;
         }
 
-        public static bool RadioButtonBool(string label, bool active)
+        public static unsafe bool RadioButtonBool(string label, bool active)
         {
-            return ImGuiNative.igRadioButtonBool(label, active);
+            return ImGuiNative.igRadioButtonBool(_utf8.FromStr(label), active);
         }
 
-        public static bool BeginCombo(string label, string previewValue, ComboFlags flags)
-            => ImGuiNative.igBeginCombo(label, previewValue, flags);
+        public static unsafe bool BeginCombo(string label, string previewValue, ComboFlags flags)
+        {
+            return ImGuiNative.igBeginCombo(_utf8.FromStr(label), previewValue, flags);
+        }
 
         public static void EndCombo() => ImGuiNative.igEndCombo();
 
-        public unsafe static bool Combo(string label, ref int current_item, string[] items)
+        public static unsafe bool Combo(string label, ref int current_item, string[] items)
         {
-            return ImGuiNative.igCombo(label, ref current_item, items, items.Length, 5);
+            return ImGuiNative.igCombo(_utf8.FromStr(label), ref current_item, items, items.Length, 5);
         }
 
-        public unsafe static bool Combo(string label, ref int current_item, string[] items, int heightInItems)
+        public static unsafe bool Combo(string label, ref int current_item, string[] items, int heightInItems)
         {
-            return ImGuiNative.igCombo(label, ref current_item, items, items.Length, heightInItems);
+            return ImGuiNative.igCombo(_utf8.FromStr(label), ref current_item, items, items.Length, heightInItems);
         }
 
-        public static bool ColorButton(string desc_id, Vector4 color, ColorEditFlags flags, Vector2 size)
+        public static unsafe bool ColorButton(string desc_id, Vector4 color, ColorEditFlags flags, Vector2 size)
         {
-            return ImGuiNative.igColorButton(desc_id, color, flags, size);
+            return ImGuiNative.igColorButton(_utf8.FromStr(desc_id), color, flags, size);
         }
 
         public static unsafe bool ColorEdit3(string label, ref float r, ref float g, ref float b, ColorEditFlags flags = ColorEditFlags.Default)
         {
             Vector3 localColor = new Vector3(r, g, b);
-            bool result = ImGuiNative.igColorEdit3(label, &localColor, flags);
+            bool result = ImGuiNative.igColorEdit3(_utf8.FromStr(label), &localColor, flags);
             if (result)
             {
                 r = localColor.X;
@@ -208,7 +208,7 @@ namespace ImGuiNET
         public static unsafe bool ColorEdit3(string label, ref Vector3 color, ColorEditFlags flags = ColorEditFlags.Default)
         {
             Vector3 localColor = color;
-            bool result = ImGuiNative.igColorEdit3(label, &localColor, flags);
+            bool result = ImGuiNative.igColorEdit3(_utf8.FromStr(label), &localColor, flags);
             if (result)
             {
                 color = localColor;
@@ -220,7 +220,7 @@ namespace ImGuiNET
         public static unsafe bool ColorEdit4(string label, ref float r, ref float g, ref float b, ref float a, ColorEditFlags flags = ColorEditFlags.Default)
         {
             Vector4 localColor = new Vector4(r, g, b, a);
-            bool result = ImGuiNative.igColorEdit4(label, &localColor, flags);
+            bool result = ImGuiNative.igColorEdit4(_utf8.FromStr(label), &localColor, flags);
             if (result)
             {
                 r = localColor.X;
@@ -235,7 +235,7 @@ namespace ImGuiNET
         public static unsafe bool ColorEdit4(string label, ref Vector4 color, ColorEditFlags flags = ColorEditFlags.Default)
         {
             Vector4 localColor = color;
-            bool result = ImGuiNative.igColorEdit4(label, &localColor, flags);
+            bool result = ImGuiNative.igColorEdit4(_utf8.FromStr(label), &localColor, flags);
             if (result)
             {
                 color = localColor;
@@ -247,7 +247,7 @@ namespace ImGuiNET
         public static unsafe bool ColorPicker3(string label, ref Vector3 color, ColorEditFlags flags = ColorEditFlags.Default)
         {
             Vector3 localColor = color;
-            bool result = ImGuiNative.igColorPicker3(label, &localColor, flags);
+            bool result = ImGuiNative.igColorPicker3(_utf8.FromStr(label), &localColor, flags);
             if (result)
             {
                 color = localColor;
@@ -258,7 +258,7 @@ namespace ImGuiNET
         public static unsafe bool ColorPicker4(string label, ref Vector4 color, ColorEditFlags flags = ColorEditFlags.Default)
         {
             Vector4 localColor = color;
-            bool result = ImGuiNative.igColorPicker4(label, &localColor, flags);
+            bool result = ImGuiNative.igColorPicker4(_utf8.FromStr(label), &localColor, flags);
             if (result)
             {
                 color = localColor;
@@ -266,7 +266,7 @@ namespace ImGuiNET
             return result;
         }
 
-        public unsafe static void PlotLines(
+        public static unsafe void PlotLines(
             string label,
             float[] values,
             int valuesOffset,
@@ -279,7 +279,7 @@ namespace ImGuiNET
             fixed (float* valuesBasePtr = values)
             {
                 ImGuiNative.igPlotLines(
-                    label,
+                    _utf8.FromStr(label),
                     valuesBasePtr,
                     values.Length,
                     valuesOffset,
@@ -301,12 +301,12 @@ namespace ImGuiNET
             ImGuiNative.igShowFontSelector(label);
         }
 
-        public unsafe static void PlotHistogram(string label, float[] values, int valuesOffset, string overlayText, float scaleMin, float scaleMax, Vector2 graphSize, int stride)
+        public static unsafe void PlotHistogram(string label, float[] values, int valuesOffset, string overlayText, float scaleMin, float scaleMax, Vector2 graphSize, int stride)
         {
             fixed (float* valuesBasePtr = values)
             {
                 ImGuiNative.igPlotHistogram(
-                    label,
+                    _utf8.FromStr(label),
                     valuesBasePtr,
                     values.Length,
                     valuesOffset,
@@ -318,72 +318,72 @@ namespace ImGuiNET
             }
         }
 
-        public static bool SliderFloat(string sliderLabel, ref float value, float min, float max, string displayText, float power)
+        public static unsafe bool SliderFloat(string label, ref float value, float min, float max, string displayText, float power)
         {
-            return ImGuiNative.igSliderFloat(sliderLabel, ref value, min, max, displayText, power);
+            return ImGuiNative.igSliderFloat(_utf8.FromStr(label), ref value, min, max, displayText, power);
         }
 
-        public static bool SliderVector2(string label, ref Vector2 value, float min, float max, string displayText, float power)
+        public static unsafe bool SliderVector2(string label, ref Vector2 value, float min, float max, string displayText, float power)
         {
-            return ImGuiNative.igSliderFloat2(label, ref value, min, max, displayText, power);
+            return ImGuiNative.igSliderFloat2(_utf8.FromStr(label), ref value, min, max, displayText, power);
         }
 
-        public static bool SliderVector3(string label, ref Vector3 value, float min, float max, string displayText, float power)
+        public static unsafe bool SliderVector3(string label, ref Vector3 value, float min, float max, string displayText, float power)
         {
-            return ImGuiNative.igSliderFloat3(label, ref value, min, max, displayText, power);
+            return ImGuiNative.igSliderFloat3(_utf8.FromStr(label), ref value, min, max, displayText, power);
         }
 
-        public static bool SliderVector4(string label, ref Vector4 value, float min, float max, string displayText, float power)
+        public static unsafe bool SliderVector4(string label, ref Vector4 value, float min, float max, string displayText, float power)
         {
-            return ImGuiNative.igSliderFloat4(label, ref value, min, max, displayText, power);
+            return ImGuiNative.igSliderFloat4(_utf8.FromStr(label), ref value, min, max, displayText, power);
         }
 
-        public static bool SliderAngle(string label, ref float radians, float minDegrees, float maxDegrees)
+        public static unsafe bool SliderAngle(string label, ref float radians, float minDegrees, float maxDegrees)
         {
-            return ImGuiNative.igSliderAngle(label, ref radians, minDegrees, maxDegrees);
+            return ImGuiNative.igSliderAngle(_utf8.FromStr(label), ref radians, minDegrees, maxDegrees);
         }
 
-        public static bool SliderInt(string sliderLabel, ref int value, int min, int max, string displayText)
+        public static unsafe bool SliderInt(string label, ref int value, int min, int max, string displayText)
         {
-            return ImGuiNative.igSliderInt(sliderLabel, ref value, min, max, displayText);
+            return ImGuiNative.igSliderInt(_utf8.FromStr(label), ref value, min, max, displayText);
         }
 
-        public static bool SliderInt2(string label, ref Int2 value, int min, int max, string displayText)
+        public static unsafe bool SliderInt2(string label, ref Int2 value, int min, int max, string displayText)
         {
-            return ImGuiNative.igSliderInt2(label, ref value, min, max, displayText);
+            return ImGuiNative.igSliderInt2(_utf8.FromStr(label), ref value, min, max, displayText);
         }
 
-        public static bool SliderInt3(string label, ref Int3 value, int min, int max, string displayText)
+        public static unsafe bool SliderInt3(string label, ref Int3 value, int min, int max, string displayText)
         {
-            return ImGuiNative.igSliderInt3(label, ref value, min, max, displayText);
+            return ImGuiNative.igSliderInt3(_utf8.FromStr(label), ref value, min, max, displayText);
         }
 
-        public static bool SliderInt4(string label, ref Int4 value, int min, int max, string displayText)
+        public static unsafe bool SliderInt4(string label, ref Int4 value, int min, int max, string displayText)
         {
-            return ImGuiNative.igSliderInt4(label, ref value, min, max, displayText);
+            return ImGuiNative.igSliderInt4(_utf8.FromStr(label), ref value, min, max, displayText);
         }
 
-        public static bool DragFloat(string label, ref float value, float min, float max, float dragSpeed = 1f, string displayFormat = "%f", float dragPower = 1f)
+        public static unsafe bool DragFloat(string label, ref float value, float min, float max, float dragSpeed = 1f, string displayFormat = "%f", float dragPower = 1f)
         {
-            return ImGuiNative.igDragFloat(label, ref value, dragSpeed, min, max, displayFormat, dragPower);
+            return ImGuiNative.igDragFloat(_utf8.FromStr(label), ref value, dragSpeed, min, max, displayFormat, dragPower);
         }
 
-        public static bool DragVector2(string label, ref Vector2 value, float min, float max, float dragSpeed = 1f, string displayFormat = "%f", float dragPower = 1f)
+        public static unsafe bool DragVector2(string label, ref Vector2 value, float min, float max, float dragSpeed = 1f, string displayFormat = "%f", float dragPower = 1f)
         {
-            return ImGuiNative.igDragFloat2(label, ref value, dragSpeed, min, max, displayFormat, dragPower);
+            return ImGuiNative.igDragFloat2(_utf8.FromStr(label), ref value, dragSpeed, min, max, displayFormat, dragPower);
         }
 
-        public static bool DragVector3(string label, ref Vector3 value, float min, float max, float dragSpeed = 1f, string displayFormat = "%f", float dragPower = 1f)
+        public static unsafe bool DragVector3(string label, ref Vector3 value, float min, float max, float dragSpeed = 1f, string displayFormat = "%f", float dragPower = 1f)
         {
-            return ImGuiNative.igDragFloat3(label, ref value, dragSpeed, min, max, displayFormat, dragPower);
+            return ImGuiNative.igDragFloat3(_utf8.FromStr(label), ref value, dragSpeed, min, max, displayFormat, dragPower);
         }
 
-        public static bool DragVector4(string label, ref Vector4 value, float min, float max, float dragSpeed = 1f, string displayFormat = "%f", float dragPower = 1f)
+        public static unsafe bool DragVector4(string label, ref Vector4 value, float min, float max, float dragSpeed = 1f, string displayFormat = "%f", float dragPower = 1f)
         {
-            return ImGuiNative.igDragFloat4(label, ref value, dragSpeed, min, max, displayFormat, dragPower);
+            return ImGuiNative.igDragFloat4(_utf8.FromStr(label), ref value, dragSpeed, min, max, displayFormat, dragPower);
         }
 
-        public static bool DragFloatRange2(
+        public static unsafe bool DragFloatRange2(
             string label,
             ref float currentMinValue,
             ref float currentMaxValue,
@@ -394,30 +394,30 @@ namespace ImGuiNET
             string displayFormatMax = null,
             float power = 1.0f)
         {
-            return ImGuiNative.igDragFloatRange2(label, ref currentMinValue, ref currentMaxValue, speed, minValueLimit, maxValueLimit, displayFormat, displayFormatMax, power);
+            return ImGuiNative.igDragFloatRange2(_utf8.FromStr(label), ref currentMinValue, ref currentMaxValue, speed, minValueLimit, maxValueLimit, displayFormat, displayFormatMax, power);
         }
 
-        public static bool DragInt(string label, ref int value, float speed, int minValue, int maxValue, string displayText)
+        public static unsafe bool DragInt(string label, ref int value, float speed, int minValue, int maxValue, string displayText)
         {
-            return ImGuiNative.igDragInt(label, ref value, speed, minValue, maxValue, displayText);
+            return ImGuiNative.igDragInt(_utf8.FromStr(label), ref value, speed, minValue, maxValue, displayText);
         }
 
-        public static bool DragInt2(string label, ref Int2 value, float speed, int minValue, int maxValue, string displayText)
+        public static unsafe bool DragInt2(string label, ref Int2 value, float speed, int minValue, int maxValue, string displayText)
         {
-            return ImGuiNative.igDragInt2(label, ref value, speed, minValue, maxValue, displayText);
+            return ImGuiNative.igDragInt2(_utf8.FromStr(label), ref value, speed, minValue, maxValue, displayText);
         }
 
-        public static bool DragInt3(string label, ref Int3 value, float speed, int minValue, int maxValue, string displayText)
+        public static unsafe bool DragInt3(string label, ref Int3 value, float speed, int minValue, int maxValue, string displayText)
         {
-            return ImGuiNative.igDragInt3(label, ref value, speed, minValue, maxValue, displayText);
+            return ImGuiNative.igDragInt3(_utf8.FromStr(label), ref value, speed, minValue, maxValue, displayText);
         }
 
-        public static bool DragInt4(string label, ref Int4 value, float speed, int minValue, int maxValue, string displayText)
+        public static unsafe bool DragInt4(string label, ref Int4 value, float speed, int minValue, int maxValue, string displayText)
         {
-            return ImGuiNative.igDragInt4(label, ref value, speed, minValue, maxValue, displayText);
+            return ImGuiNative.igDragInt4(_utf8.FromStr(label), ref value, speed, minValue, maxValue, displayText);
         }
 
-        public static bool DragIntRange2(
+        public static unsafe bool DragIntRange2(
             string label,
             ref int currentMinValue,
             ref int currentMaxValue,
@@ -428,7 +428,7 @@ namespace ImGuiNET
             string displayFormatMax = null)
         {
             return ImGuiNative.igDragIntRange2(
-                label,
+                _utf8.FromStr(label),
                 ref currentMinValue,
                 ref currentMaxValue,
                 speed,
@@ -438,14 +438,14 @@ namespace ImGuiNET
                 displayFormatMax);
         }
 
-        public static bool Button(string message)
+        public static unsafe bool Button(string message)
         {
-            return ImGuiNative.igButton(message, Vector2.Zero);
+            return ImGuiNative.igButton(_utf8.FromStr(message), Vector2.Zero);
         }
 
-        public static bool Button(string message, Vector2 size)
+        public static unsafe bool Button(string message, Vector2 size)
         {
-            return ImGuiNative.igButton(message, size);
+            return ImGuiNative.igButton(_utf8.FromStr(message), size);
         }
 
         public static void SetNextWindowSize(Vector2 size, Condition condition)
@@ -522,40 +522,40 @@ namespace ImGuiNET
 
         public static bool BeginWindow(string windowTitle) => BeginWindow(windowTitle, WindowFlags.Default);
 
-        public static bool BeginWindow(string windowTitle, WindowFlags flags)
+        public static unsafe bool BeginWindow(string windowTitle, WindowFlags flags)
         {
             bool opened = true;
-            return ImGuiNative.igBegin(windowTitle, ref opened, flags);
+            return ImGuiNative.igBegin(_utf8.FromStr(windowTitle), ref opened, flags);
         }
 
-        public static bool BeginWindow(string windowTitle, ref bool opened, WindowFlags flags)
+        public static unsafe bool BeginWindow(string windowTitle, ref bool opened, WindowFlags flags)
         {
-            return ImGuiNative.igBegin(windowTitle, ref opened, flags);
+            return ImGuiNative.igBegin(_utf8.FromStr(windowTitle), ref opened, flags);
         }
 
-        public static bool BeginWindow(string windowTitle, ref bool opened, float backgroundAlpha, WindowFlags flags)
+        public static unsafe bool BeginWindow(string windowTitle, ref bool opened, float backgroundAlpha, WindowFlags flags)
         {
-            return ImGuiNative.igBegin2(windowTitle, ref opened, new Vector2(), backgroundAlpha, flags);
+            return ImGuiNative.igBegin2(_utf8.FromStr(windowTitle), ref opened, new Vector2(), backgroundAlpha, flags);
         }
 
-        public static bool BeginWindow(string windowTitle, ref bool opened, Vector2 startingSize, WindowFlags flags)
+        public static unsafe bool BeginWindow(string windowTitle, ref bool opened, Vector2 startingSize, WindowFlags flags)
         {
-            return ImGuiNative.igBegin2(windowTitle, ref opened, startingSize, 1f, flags);
+            return ImGuiNative.igBegin2(_utf8.FromStr(windowTitle), ref opened, startingSize, 1f, flags);
         }
 
-        public static bool BeginWindow(string windowTitle, ref bool opened, Vector2 startingSize, float backgroundAlpha, WindowFlags flags)
+        public static unsafe bool BeginWindow(string windowTitle, ref bool opened, Vector2 startingSize, float backgroundAlpha, WindowFlags flags)
         {
-            return ImGuiNative.igBegin2(windowTitle, ref opened, startingSize, backgroundAlpha, flags);
+            return ImGuiNative.igBegin2(_utf8.FromStr(windowTitle), ref opened, startingSize, backgroundAlpha, flags);
         }
 
-        public static bool BeginMenu(string label)
+        public static unsafe bool BeginMenu(string label)
         {
-            return ImGuiNative.igBeginMenu(label, true);
+            return ImGuiNative.igBeginMenu(_utf8.FromStr(label), true);
         }
 
-        public static bool BeginMenu(string label, bool enabled)
+        public static unsafe bool BeginMenu(string label, bool enabled = true)
         {
-            return ImGuiNative.igBeginMenu(label, enabled);
+            return ImGuiNative.igBeginMenu(_utf8.FromStr(label), enabled);
         }
 
         public static bool BeginMenuBar()
@@ -598,9 +598,9 @@ namespace ImGuiNET
             return MenuItem(label, string.Empty, false, enabled);
         }
 
-        public static bool MenuItem(string label, string shortcut, bool selected, bool enabled)
+        public static unsafe bool MenuItem(string label, string shortcut, bool selected, bool enabled)
         {
-            return ImGuiNative.igMenuItem(label, shortcut, selected, enabled);
+            return ImGuiNative.igMenuItem(_utf8.FromStr(label), shortcut, selected, enabled);
         }
 
         public static unsafe bool InputText(string label, byte[] textBuffer, uint bufferSize, InputTextFlags flags, TextEditCallback textEditCallback)
@@ -624,7 +624,7 @@ namespace ImGuiNET
 
         public static unsafe bool InputText(string label, IntPtr textBuffer, uint bufferSize, InputTextFlags flags, TextEditCallback textEditCallback, IntPtr userData)
         {
-            return ImGuiNative.igInputText(label, textBuffer, bufferSize, flags, textEditCallback, userData.ToPointer());
+            return ImGuiNative.igInputText(_utf8.FromStr(label), textBuffer, bufferSize, flags, textEditCallback, userData.ToPointer());
         }
 
         public static void EndWindow()
@@ -655,7 +655,7 @@ namespace ImGuiNET
 
         public static unsafe void InputTextMultiline(string label, IntPtr textBuffer, uint bufferSize, Vector2 size, InputTextFlags flags, TextEditCallback callback)
         {
-            ImGuiNative.igInputTextMultiline(label, textBuffer, bufferSize, size, flags, callback, null);
+            ImGuiNative.igInputTextMultiline(_utf8.FromStr(label), textBuffer, bufferSize, size, flags, callback, null);
         }
 
         public static unsafe DrawData* GetDrawData()
@@ -665,7 +665,7 @@ namespace ImGuiNET
 
         public static unsafe void InputTextMultiline(string label, IntPtr textBuffer, uint bufferSize, Vector2 size, InputTextFlags flags, TextEditCallback callback, IntPtr userData)
         {
-            ImGuiNative.igInputTextMultiline(label, textBuffer, bufferSize, size, flags, callback, userData.ToPointer());
+            ImGuiNative.igInputTextMultiline(_utf8.FromStr(label), textBuffer, bufferSize, size, flags, callback, userData.ToPointer());
         }
 
         public static bool BeginChildFrame(uint id, Vector2 size, WindowFlags flags)
@@ -935,9 +935,9 @@ namespace ImGuiNET
             ImGuiNative.igEndMainMenuBar();
         }
 
-        public static bool SmallButton(string label)
+        public static unsafe bool SmallButton(string label)
         {
-            return ImGuiNative.igSmallButton(label);
+            return ImGuiNative.igSmallButton(_utf8.FromStr(label));
         }
 
         public static bool BeginPopupModal(string name)
@@ -952,13 +952,13 @@ namespace ImGuiNET
 
         public static unsafe bool BeginPopupModal(string name, WindowFlags extra_flags)
         {
-            return ImGuiNative.igBeginPopupModal(name, null, extra_flags);
+            return ImGuiNative.igBeginPopupModal(_utf8.FromStr(name), null, extra_flags);
         }
 
         public static unsafe bool BeginPopupModal(string name, ref bool p_opened, WindowFlags extra_flags)
         {
             byte value = p_opened ? (byte)1 : (byte)0;
-            bool result = ImGuiNative.igBeginPopupModal(name, &value, extra_flags);
+            bool result = ImGuiNative.igBeginPopupModal(_utf8.FromStr(name), &value, extra_flags);
 
             p_opened = value == 1 ? true : false;
             return result;
@@ -969,19 +969,19 @@ namespace ImGuiNET
             return Selectable(label, isSelected, flags, new Vector2());
         }
 
-        public static bool Selectable(string label, bool isSelected, SelectableFlags flags, Vector2 size)
+        public static unsafe bool Selectable(string label, bool isSelected, SelectableFlags flags, Vector2 size)
         {
-            return ImGuiNative.igSelectable(label, isSelected, flags, size);
+            return ImGuiNative.igSelectable(_utf8.FromStr(label), isSelected, flags, size);
         }
 
-        public static bool SelectableEx(string label, ref bool isSelected)
+        public static unsafe bool SelectableEx(string label, ref bool isSelected)
         {
-            return ImGuiNative.igSelectableEx(label, ref isSelected, SelectableFlags.Default, new Vector2());
+            return ImGuiNative.igSelectableEx(_utf8.FromStr(label), ref isSelected, SelectableFlags.Default, new Vector2());
         }
 
-        public static bool SelectableEx(string label, ref bool isSelected, SelectableFlags flags, Vector2 size)
+        public static unsafe bool SelectableEx(string label, ref bool isSelected, SelectableFlags flags, Vector2 size)
         {
-            return ImGuiNative.igSelectableEx(label, ref isSelected, flags, size);
+            return ImGuiNative.igSelectableEx(_utf8.FromStr(label), ref isSelected, flags, size);
         }
 
         public static unsafe Vector2 GetTextSize(string text, float wrapWidth = Int32.MaxValue)
@@ -1014,9 +1014,9 @@ namespace ImGuiNET
             ImGuiNative.igEndPopup();
         }
 
-        public static bool IsPopupOpen(string id)
+        public static unsafe bool IsPopupOpen(string id)
         {
-            return ImGuiNative.igIsPopupOpen(id);
+            return ImGuiNative.igIsPopupOpen(_utf8.FromStr(id));
         }
 
         public static unsafe void Dummy(Vector2 size)
@@ -1148,9 +1148,9 @@ namespace ImGuiNET
 
         public static unsafe DrawList GetOverlayDrawList() => new DrawList(ImGuiNative.igGetOverlayDrawList());
 
-        public static void SetTooltip(string text)
+        public static unsafe void SetTooltip(string text)
         {
-            ImGuiNative.igSetTooltip(text);
+            ImGuiNative.igSetTooltip(_utf8.FromStr(text));
         }
 
         public static void SetNextTreeNodeOpen(bool opened)
@@ -1163,14 +1163,14 @@ namespace ImGuiNET
             ImGuiNative.igSetNextTreeNodeOpen(opened, setCondition);
         }
 
-        public static bool TreeNode(string label)
+        public static unsafe bool TreeNode(string label)
         {
-            return ImGuiNative.igTreeNode(label);
+            return ImGuiNative.igTreeNode(_utf8.FromStr(label));
         }
 
-        public static bool TreeNodeEx(string label, TreeNodeFlags flags = 0)
+        public static unsafe bool TreeNodeEx(string label, TreeNodeFlags flags = 0)
         {
-            return ImGuiNative.igTreeNodeEx(label, flags);
+            return ImGuiNative.igTreeNodeEx(_utf8.FromStr(label), flags);
         }
 
         public static void TreePop()
@@ -1247,6 +1247,16 @@ namespace ImGuiNET
         public static void CalcListClipping(int itemsCount, float itemsHeight, ref int outItemsDisplayStart, ref int outItemsDisplayEnd)
         {
             ImGuiNative.igCalcListClipping(itemsCount, itemsHeight, ref outItemsDisplayStart, ref outItemsDisplayEnd);
+        }
+
+        public static unsafe void SetClipboardText(string text)
+        {
+            ImGuiNative.igSetClipboardText(_utf8.FromStr(text));
+        }
+
+        public static unsafe string GetClipboardText()
+        {
+            return _utf8.ToStr(ImGuiNative.igGetClipboardText());
         }
     }
 }

--- a/src/ImGui.NET/ImGuiNative.cs
+++ b/src/ImGui.NET/ImGuiNative.cs
@@ -47,10 +47,10 @@ namespace ImGuiNET
         // Window
         [DllImport(cimguiLib, CallingConvention = CallingConvention.Cdecl)]
         [return: MarshalAs(UnmanagedType.I1)]
-        public static extern bool igBegin(string name, ref bool p_opened, WindowFlags flags);
+        public static extern bool igBegin(byte* name, ref bool p_opened, WindowFlags flags);
         [DllImport(cimguiLib, CallingConvention = CallingConvention.Cdecl)]
         [return: MarshalAs(UnmanagedType.I1)]
-        public static extern bool igBegin2(string name, ref bool p_opened, Vector2 size_on_first_use, float bg_alpha, WindowFlags flags);
+        public static extern bool igBegin2(byte* name, ref bool p_opened, Vector2 size_on_first_use, float bg_alpha, WindowFlags flags);
         [DllImport(cimguiLib, CallingConvention = CallingConvention.Cdecl)]
         public static extern void igEnd();
         [DllImport(cimguiLib, CallingConvention = CallingConvention.Cdecl)]
@@ -116,13 +116,13 @@ namespace ImGuiNET
         [DllImport(cimguiLib, CallingConvention = CallingConvention.Cdecl)]
         public static extern void igSetWindowFocus(); //(not recommended)
         [DllImport(cimguiLib, CallingConvention = CallingConvention.Cdecl)]
-        public static extern void igSetWindowPosByName(string name, Vector2 pos, Condition cond);
+        public static extern void igSetWindowPosByName(byte* name, Vector2 pos, Condition cond);
         [DllImport(cimguiLib, CallingConvention = CallingConvention.Cdecl)]
-        public static extern void igSetWindowSize2(string name, Vector2 size, Condition cond);
+        public static extern void igSetWindowSize2(byte* name, Vector2 size, Condition cond);
         [DllImport(cimguiLib, CallingConvention = CallingConvention.Cdecl)]
-        public static extern void igSetWindowCollapsed2(string name, bool collapsed, Condition cond);
+        public static extern void igSetWindowCollapsed2(byte* name, bool collapsed, Condition cond);
         [DllImport(cimguiLib, CallingConvention = CallingConvention.Cdecl)]
-        public static extern void igSetWindowFocus2(string name);
+        public static extern void igSetWindowFocus2(byte* name);
 
         [DllImport(cimguiLib, CallingConvention = CallingConvention.Cdecl)]
         public static extern float igGetScrollX();
@@ -286,33 +286,33 @@ namespace ImGuiNET
 
         // Widgets
         [DllImport(cimguiLib, CallingConvention = CallingConvention.Cdecl)]
-        public static extern void igText(string fmt);
+        public static extern void igText(byte* fmt);
 
         [DllImport(cimguiLib, CallingConvention = CallingConvention.Cdecl)]
-        public static extern void igTextColored(Vector4 col, string fmt);
+        public static extern void igTextColored(Vector4 col, byte* fmt);
 
         [DllImport(cimguiLib, CallingConvention = CallingConvention.Cdecl)]
-        public static extern void igTextDisabled(string fmt);
+        public static extern void igTextDisabled(byte* fmt);
         [DllImport(cimguiLib, CallingConvention = CallingConvention.Cdecl)]
-        public static extern void igTextWrapped(string fmt);
+        public static extern void igTextWrapped(byte* fmt);
 
         [DllImport(cimguiLib, CallingConvention = CallingConvention.Cdecl)]
         public static extern void igTextUnformatted(byte* text, byte* text_end);
 
         [DllImport(cimguiLib, CallingConvention = CallingConvention.Cdecl)]
-        public static extern void igLabelText(string label, string fmt);
+        public static extern void igLabelText(byte* label, byte* fmt);
 
         [DllImport(cimguiLib, CallingConvention = CallingConvention.Cdecl)]
         public static extern void igBullet();
 
         [DllImport(cimguiLib, CallingConvention = CallingConvention.Cdecl)]
-        public static extern void igBulletText(string fmt);
+        public static extern void igBulletText(byte* fmt);
         [DllImport(cimguiLib, CallingConvention = CallingConvention.Cdecl)]
         [return: MarshalAs(UnmanagedType.I1)]
-        public static extern bool igButton(string label, Vector2 size);
+        public static extern bool igButton(byte* label, Vector2 size);
         [DllImport(cimguiLib, CallingConvention = CallingConvention.Cdecl)]
         [return: MarshalAs(UnmanagedType.I1)]
-        public static extern bool igSmallButton(string label);
+        public static extern bool igSmallButton(byte* label);
         [DllImport(cimguiLib, CallingConvention = CallingConvention.Cdecl)]
         [return: MarshalAs(UnmanagedType.I1)]
         public static extern bool igInvisibleButton(string str_id, Vector2 size);
@@ -323,32 +323,32 @@ namespace ImGuiNET
         public static extern bool igImageButton(IntPtr user_texture_id, Vector2 size, Vector2 uv0, Vector2 uv1, int frame_padding, Vector4 bg_col, Vector4 tint_col);
         [DllImport(cimguiLib, CallingConvention = CallingConvention.Cdecl)]
         [return: MarshalAs(UnmanagedType.I1)]
-        public static extern bool igCheckbox(string label, ref bool v);
+        public static extern bool igCheckbox(byte* label, ref bool v);
         [DllImport(cimguiLib, CallingConvention = CallingConvention.Cdecl)]
         [return: MarshalAs(UnmanagedType.I1)]
-        public static extern bool igCheckboxFlags(string label, UIntPtr* flags, uint flags_value);
+        public static extern bool igCheckboxFlags(byte* label, UIntPtr* flags, uint flags_value);
         [DllImport(cimguiLib, CallingConvention = CallingConvention.Cdecl)]
         [return: MarshalAs(UnmanagedType.I1)]
-        public static extern bool igRadioButtonBool(string label, bool active);
+        public static extern bool igRadioButtonBool(byte* label, bool active);
         [DllImport(cimguiLib, CallingConvention = CallingConvention.Cdecl)]
         [return: MarshalAs(UnmanagedType.I1)]
-        public static extern bool igRadioButton(string label, int* v, int v_button);
+        public static extern bool igRadioButton(byte* label, int* v, int v_button);
 
         [DllImport(cimguiLib, CallingConvention = CallingConvention.Cdecl)]
         [return: MarshalAs(UnmanagedType.I1)]
-        public static extern bool igBeginCombo(string label, string preview_value, ComboFlags flags);
+        public static extern bool igBeginCombo(byte* label, string preview_value, ComboFlags flags);
         [DllImport(cimguiLib, CallingConvention = CallingConvention.Cdecl)]
         public static extern void igEndCombo();
 
         [DllImport(cimguiLib, CallingConvention = CallingConvention.Cdecl)]
         [return: MarshalAs(UnmanagedType.I1)]
-        public static extern bool igCombo(string label, ref int current_item, string[] items, int items_count, int height_in_items);
+        public static extern bool igCombo(byte* label, ref int current_item, string[] items, int items_count, int height_in_items);
         [DllImport(cimguiLib, CallingConvention = CallingConvention.Cdecl)]
         [return: MarshalAs(UnmanagedType.I1)]
-        public static extern bool igCombo2(string label, ref int current_item, string items_separated_by_zeros, int height_in_items);
+        public static extern bool igCombo2(byte* label, ref int current_item, string items_separated_by_zeros, int height_in_items);
         [DllImport(cimguiLib, CallingConvention = CallingConvention.Cdecl)]
         [return: MarshalAs(UnmanagedType.I1)]
-        public static extern bool igCombo3(string label, ref int current_item, ItemSelectedCallback items_getter, IntPtr data, int items_count, int height_in_items);
+        public static extern bool igCombo3(byte* label, ref int current_item, ItemSelectedCallback items_getter, IntPtr data, int items_count, int height_in_items);
 
         public delegate IntPtr ImGuiContextAllocationFunction(UIntPtr size);
         public delegate void ImGuiContextFreeFunction(IntPtr ptr);
@@ -364,144 +364,144 @@ namespace ImGuiNET
 
         [DllImport(cimguiLib, CallingConvention = CallingConvention.Cdecl)]
         [return: MarshalAs(UnmanagedType.I1)]
-        public static extern bool igColorButton(string desc_id, Vector4 col, ColorEditFlags flags, Vector2 size);
+        public static extern bool igColorButton(byte* desc_id, Vector4 col, ColorEditFlags flags, Vector2 size);
         [DllImport(cimguiLib, CallingConvention = CallingConvention.Cdecl)]
         [return: MarshalAs(UnmanagedType.I1)]
-        public static extern bool igColorEdit3(string label, Vector3* col, ColorEditFlags flags = 0);
+        public static extern bool igColorEdit3(byte* label, Vector3* col, ColorEditFlags flags = 0);
         [DllImport(cimguiLib, CallingConvention = CallingConvention.Cdecl)]
         [return: MarshalAs(UnmanagedType.I1)]
-        public static extern bool igColorEdit4(string label, Vector4* col, ColorEditFlags flags = 0);
+        public static extern bool igColorEdit4(byte* label, Vector4* col, ColorEditFlags flags = 0);
         [DllImport(cimguiLib, CallingConvention = CallingConvention.Cdecl)]
         [return: MarshalAs(UnmanagedType.I1)]
-        public static extern bool igColorPicker3(string label, Vector3* col, ColorEditFlags flags = 0);
+        public static extern bool igColorPicker3(byte* label, Vector3* col, ColorEditFlags flags = 0);
         [DllImport(cimguiLib, CallingConvention = CallingConvention.Cdecl)]
         [return: MarshalAs(UnmanagedType.I1)]
-        public static extern bool igColorPicker4(string label, Vector4* col, ColorEditFlags flags = 0, float* ref_col = null);
+        public static extern bool igColorPicker4(byte* label, Vector4* col, ColorEditFlags flags = 0, float* ref_col = null);
         [DllImport(cimguiLib, CallingConvention = CallingConvention.Cdecl)]
         public static extern void SetColorEditOptions(ColorEditFlags flags);
 
         [DllImport(cimguiLib, CallingConvention = CallingConvention.Cdecl)]
-        public static extern void igPlotLines(string label, float* values, int values_count, int values_offset, string overlay_text, float scale_min, float scale_max, Vector2 graph_size, int stride);
+        public static extern void igPlotLines(byte* label, float* values, int values_count, int values_offset, string overlay_text, float scale_min, float scale_max, Vector2 graph_size, int stride);
         public delegate float ImGuiPlotHistogramValuesGetter(IntPtr data, int idx);
         [DllImport(cimguiLib, CallingConvention = CallingConvention.Cdecl)]
-        public static extern void igPlotLines2(string label, ImGuiPlotHistogramValuesGetter values_getter, void* data, int values_count, int values_offset, string overlay_text, float scale_min, float scale_max, Vector2 graph_size);
+        public static extern void igPlotLines2(byte* label, ImGuiPlotHistogramValuesGetter values_getter, void* data, int values_count, int values_offset, string overlay_text, float scale_min, float scale_max, Vector2 graph_size);
         [DllImport(cimguiLib, CallingConvention = CallingConvention.Cdecl)]
-        public static extern void igPlotHistogram(string label, float* values, int values_count, int values_offset, string overlay_text, float scale_min, float scale_max, Vector2 graph_size, int stride);
+        public static extern void igPlotHistogram(byte* label, float* values, int values_count, int values_offset, string overlay_text, float scale_min, float scale_max, Vector2 graph_size, int stride);
         [DllImport(cimguiLib, CallingConvention = CallingConvention.Cdecl)]
-        public static extern void igPlotHistogram2(string label, ImGuiPlotHistogramValuesGetter values_getter, void* data, int values_count, int values_offset, string overlay_text, float scale_min, float scale_max, Vector2 graph_size);
+        public static extern void igPlotHistogram2(byte* label, ImGuiPlotHistogramValuesGetter values_getter, void* data, int values_count, int values_offset, string overlay_text, float scale_min, float scale_max, Vector2 graph_size);
         [DllImport(cimguiLib, CallingConvention = CallingConvention.Cdecl)]
         public static extern void igProgressBar(float fraction, Vector2* size_arg, string overlay);
         // Widgets: Sliders (tip: ctrl+click on a slider to input text)
         [DllImport(cimguiLib, CallingConvention = CallingConvention.Cdecl)]
         [return: MarshalAs(UnmanagedType.I1)]
-        public static extern bool igSliderFloat(string label, float* v, float v_min, float v_max, string display_format, float power);
+        public static extern bool igSliderFloat(byte* label, float* v, float v_min, float v_max, string display_format, float power);
         [DllImport(cimguiLib, CallingConvention = CallingConvention.Cdecl)]
         [return: MarshalAs(UnmanagedType.I1)]
-        public static extern bool igSliderFloat(string label, ref float v, float v_min, float v_max, string display_format, float power);
+        public static extern bool igSliderFloat(byte* label, ref float v, float v_min, float v_max, string display_format, float power);
         [DllImport(cimguiLib, CallingConvention = CallingConvention.Cdecl)]
         [return: MarshalAs(UnmanagedType.I1)]
-        public static extern bool igSliderFloat2(string label, ref Vector2 v, float v_min, float v_max, string display_format, float power);
+        public static extern bool igSliderFloat2(byte* label, ref Vector2 v, float v_min, float v_max, string display_format, float power);
         [DllImport(cimguiLib, CallingConvention = CallingConvention.Cdecl)]
         [return: MarshalAs(UnmanagedType.I1)]
-        public static extern bool igSliderFloat3(string label, ref Vector3 v, float v_min, float v_max, string display_format, float power);
+        public static extern bool igSliderFloat3(byte* label, ref Vector3 v, float v_min, float v_max, string display_format, float power);
         [DllImport(cimguiLib, CallingConvention = CallingConvention.Cdecl)]
         [return: MarshalAs(UnmanagedType.I1)]
-        public static extern bool igSliderFloat4(string label, ref Vector4 v, float v_min, float v_max, string display_format, float power);
+        public static extern bool igSliderFloat4(byte* label, ref Vector4 v, float v_min, float v_max, string display_format, float power);
         [DllImport(cimguiLib, CallingConvention = CallingConvention.Cdecl)]
         [return: MarshalAs(UnmanagedType.I1)]
-        public static extern bool igSliderAngle(string label, ref float v_rad, float v_degrees_min, float v_degrees_max);
+        public static extern bool igSliderAngle(byte* label, ref float v_rad, float v_degrees_min, float v_degrees_max);
         [DllImport(cimguiLib, CallingConvention = CallingConvention.Cdecl)]
         [return: MarshalAs(UnmanagedType.I1)]
-        public static extern bool igSliderInt(string label, ref int v, int v_min, int v_max, string display_format);
+        public static extern bool igSliderInt(byte* label, ref int v, int v_min, int v_max, string display_format);
         [DllImport(cimguiLib, CallingConvention = CallingConvention.Cdecl)]
         [return: MarshalAs(UnmanagedType.I1)]
-        public static extern bool igSliderInt2(string label, ref Int2 v, int v_min, int v_max, string display_format);
+        public static extern bool igSliderInt2(byte* label, ref Int2 v, int v_min, int v_max, string display_format);
         [DllImport(cimguiLib, CallingConvention = CallingConvention.Cdecl)]
         [return: MarshalAs(UnmanagedType.I1)]
-        public static extern bool igSliderInt3(string label, ref Int3 v, int v_min, int v_max, string display_format);
+        public static extern bool igSliderInt3(byte* label, ref Int3 v, int v_min, int v_max, string display_format);
         [DllImport(cimguiLib, CallingConvention = CallingConvention.Cdecl)]
         [return: MarshalAs(UnmanagedType.I1)]
-        public static extern bool igSliderInt4(string label, ref Int4 v, int v_min, int v_max, string display_format);
+        public static extern bool igSliderInt4(byte* label, ref Int4 v, int v_min, int v_max, string display_format);
         [DllImport(cimguiLib, CallingConvention = CallingConvention.Cdecl)]
         [return: MarshalAs(UnmanagedType.I1)]
-        public static extern bool igVSliderFloat(string label, Vector2 size, float* v, float v_min, float v_max, string display_format, float power);
+        public static extern bool igVSliderFloat(byte* label, Vector2 size, float* v, float v_min, float v_max, string display_format, float power);
         [DllImport(cimguiLib, CallingConvention = CallingConvention.Cdecl)]
         [return: MarshalAs(UnmanagedType.I1)]
-        public static extern bool igVSliderInt(string label, Vector2 size, int* v, int v_min, int v_max, string display_format);
+        public static extern bool igVSliderInt(byte* label, Vector2 size, int* v, int v_min, int v_max, string display_format);
 
         // Widgets: Drags (tip: ctrl+click on a drag box to input text)
         [DllImport(cimguiLib, CallingConvention = CallingConvention.Cdecl)]
         [return: MarshalAs(UnmanagedType.I1)]
-        public static extern bool igDragFloat(string label, ref float v, float v_speed, float v_min, float v_max, string display_format, float power);     // If v_max >= v_max we have no bound
+        public static extern bool igDragFloat(byte* label, ref float v, float v_speed, float v_min, float v_max, string display_format, float power);     // If v_max >= v_max we have no bound
         [DllImport(cimguiLib, CallingConvention = CallingConvention.Cdecl)]
         [return: MarshalAs(UnmanagedType.I1)]
-        public static extern bool igDragFloat2(string label, ref Vector2 v, float v_speed, float v_min, float v_max, string display_format, float power);
+        public static extern bool igDragFloat2(byte* label, ref Vector2 v, float v_speed, float v_min, float v_max, string display_format, float power);
         [DllImport(cimguiLib, CallingConvention = CallingConvention.Cdecl)]
         [return: MarshalAs(UnmanagedType.I1)]
-        public static extern bool igDragFloat3(string label, ref Vector3 v, float v_speed, float v_min, float v_max, string display_format, float power);
+        public static extern bool igDragFloat3(byte* label, ref Vector3 v, float v_speed, float v_min, float v_max, string display_format, float power);
         [DllImport(cimguiLib, CallingConvention = CallingConvention.Cdecl)]
         [return: MarshalAs(UnmanagedType.I1)]
-        public static extern bool igDragFloat4(string label, ref Vector4 v, float v_speed, float v_min, float v_max, string display_format, float power);
+        public static extern bool igDragFloat4(byte* label, ref Vector4 v, float v_speed, float v_min, float v_max, string display_format, float power);
         [DllImport(cimguiLib, CallingConvention = CallingConvention.Cdecl)]
         [return: MarshalAs(UnmanagedType.I1)]
-        public static extern bool igDragFloatRange2(string label, ref float v_current_min, ref float v_current_max, float v_speed = 1.0f, float v_min = 0.0f, float v_max = 0.0f, string display_format = "%.3f", string display_format_max = null, float power = 1.0f);
+        public static extern bool igDragFloatRange2(byte* label, ref float v_current_min, ref float v_current_max, float v_speed = 1.0f, float v_min = 0.0f, float v_max = 0.0f, string display_format = "%.3f", string display_format_max = null, float power = 1.0f);
         [DllImport(cimguiLib, CallingConvention = CallingConvention.Cdecl)]
         [return: MarshalAs(UnmanagedType.I1)]
-        public static extern bool igDragInt(string label, ref int v, float v_speed, int v_min, int v_max, string display_format);                                       // If v_max >= v_max we have no bound
+        public static extern bool igDragInt(byte* label, ref int v, float v_speed, int v_min, int v_max, string display_format);                                       // If v_max >= v_max we have no bound
         [DllImport(cimguiLib, CallingConvention = CallingConvention.Cdecl)]
         [return: MarshalAs(UnmanagedType.I1)]
-        public static extern bool igDragInt2(string label, ref Int2 v, float v_speed, int v_min, int v_max, string display_format);
+        public static extern bool igDragInt2(byte* label, ref Int2 v, float v_speed, int v_min, int v_max, string display_format);
         [DllImport(cimguiLib, CallingConvention = CallingConvention.Cdecl)]
         [return: MarshalAs(UnmanagedType.I1)]
-        public static extern bool igDragInt3(string label, ref Int3 v, float v_speed, int v_min, int v_max, string display_format);
+        public static extern bool igDragInt3(byte* label, ref Int3 v, float v_speed, int v_min, int v_max, string display_format);
         [DllImport(cimguiLib, CallingConvention = CallingConvention.Cdecl)]
         [return: MarshalAs(UnmanagedType.I1)]
-        public static extern bool igDragInt4(string label, ref Int4 v, float v_speed, int v_min, int v_max, string display_format);
+        public static extern bool igDragInt4(byte* label, ref Int4 v, float v_speed, int v_min, int v_max, string display_format);
         [DllImport(cimguiLib, CallingConvention = CallingConvention.Cdecl)]
         [return: MarshalAs(UnmanagedType.I1)]
-        public static extern bool igDragIntRange2(string label, ref int v_current_min, ref int v_current_max, float v_speed = 1.0f, int v_min = 0, int v_max = 0, string display_format = "%.0f", string display_format_max = null);
+        public static extern bool igDragIntRange2(byte* label, ref int v_current_min, ref int v_current_max, float v_speed = 1.0f, int v_min = 0, int v_max = 0, string display_format = "%.0f", string display_format_max = null);
 
 
         // Widgets: Input
         [DllImport(cimguiLib, CallingConvention = CallingConvention.Cdecl)]
         [return: MarshalAs(UnmanagedType.I1)]
-        public static extern bool igInputText(string label, IntPtr buffer, uint buf_size, InputTextFlags flags, TextEditCallback callback, void* user_data);
+        public static extern bool igInputText(byte* label, IntPtr buffer, uint buf_size, InputTextFlags flags, TextEditCallback callback, void* user_data);
         [DllImport(cimguiLib, CallingConvention = CallingConvention.Cdecl)]
         [return: MarshalAs(UnmanagedType.I1)]
-        public static extern bool igInputTextMultiline(string label, IntPtr buffer, uint buf_size, Vector2 size, InputTextFlags flags, TextEditCallback callback, void* user_data);
+        public static extern bool igInputTextMultiline(byte* label, IntPtr buffer, uint buf_size, Vector2 size, InputTextFlags flags, TextEditCallback callback, void* user_data);
         [DllImport(cimguiLib, CallingConvention = CallingConvention.Cdecl)]
         [return: MarshalAs(UnmanagedType.I1)]
-        public static extern bool igInputFloat(string label, float* v, float step, float step_fast, int decimal_precision, InputTextFlags extra_flags);
+        public static extern bool igInputFloat(byte* label, float* v, float step, float step_fast, int decimal_precision, InputTextFlags extra_flags);
         [DllImport(cimguiLib, CallingConvention = CallingConvention.Cdecl)]
         [return: MarshalAs(UnmanagedType.I1)]
-        public static extern bool igInputFloat2(string label, Vector2 v, int decimal_precision, InputTextFlags extra_flags);
+        public static extern bool igInputFloat2(byte* label, Vector2 v, int decimal_precision, InputTextFlags extra_flags);
         [DllImport(cimguiLib, CallingConvention = CallingConvention.Cdecl)]
         [return: MarshalAs(UnmanagedType.I1)]
-        public static extern bool igInputFloat3(string label, Vector3 v, int decimal_precision, InputTextFlags extra_flags);
+        public static extern bool igInputFloat3(byte* label, Vector3 v, int decimal_precision, InputTextFlags extra_flags);
         [DllImport(cimguiLib, CallingConvention = CallingConvention.Cdecl)]
         [return: MarshalAs(UnmanagedType.I1)]
-        public static extern bool igInputFloat4(string label, Vector4 v, int decimal_precision, InputTextFlags extra_flags);
+        public static extern bool igInputFloat4(byte* label, Vector4 v, int decimal_precision, InputTextFlags extra_flags);
         [DllImport(cimguiLib, CallingConvention = CallingConvention.Cdecl)]
         [return: MarshalAs(UnmanagedType.I1)]
-        public static extern bool igInputInt(string label, int* v, int step, int step_fast, InputTextFlags extra_flags);
+        public static extern bool igInputInt(byte* label, int* v, int step, int step_fast, InputTextFlags extra_flags);
         [DllImport(cimguiLib, CallingConvention = CallingConvention.Cdecl)]
         [return: MarshalAs(UnmanagedType.I1)]
-        public static extern bool igInputInt2(string label, Int2 v, InputTextFlags extra_flags);
+        public static extern bool igInputInt2(byte* label, Int2 v, InputTextFlags extra_flags);
         [DllImport(cimguiLib, CallingConvention = CallingConvention.Cdecl)]
         [return: MarshalAs(UnmanagedType.I1)]
-        public static extern bool igInputInt3(string label, Int3 v, InputTextFlags extra_flags);
+        public static extern bool igInputInt3(byte* label, Int3 v, InputTextFlags extra_flags);
         [DllImport(cimguiLib, CallingConvention = CallingConvention.Cdecl)]
         [return: MarshalAs(UnmanagedType.I1)]
-        public static extern bool igInputInt4(string label, Int4 v, InputTextFlags extra_flags);
+        public static extern bool igInputInt4(byte* label, Int4 v, InputTextFlags extra_flags);
 
         // Widgets: Trees
         [DllImport(cimguiLib, CallingConvention = CallingConvention.Cdecl)]
         [return: MarshalAs(UnmanagedType.I1)]
-        public static extern bool igTreeNode(string str_label_id);
-
+        public static extern bool igTreeNode(byte* label);
+        
         [DllImport(cimguiLib, CallingConvention = CallingConvention.Cdecl)]
         [return: MarshalAs(UnmanagedType.I1)]
-        public static extern bool igTreeNodeEx(string label, TreeNodeFlags flags = 0);
+        public static extern bool igTreeNodeEx(byte* label, TreeNodeFlags flags = 0);        
 
         [DllImport(cimguiLib, CallingConvention = CallingConvention.Cdecl)]
         [return: MarshalAs(UnmanagedType.I1)]
@@ -525,32 +525,32 @@ namespace ImGuiNET
         public static extern void igSetNextTreeNodeOpen(bool opened, Condition cond);
         [DllImport(cimguiLib, CallingConvention = CallingConvention.Cdecl)]
         [return: MarshalAs(UnmanagedType.I1)]
-        public static extern bool igCollapsingHeader(string label, TreeNodeFlags flags = 0);
+        public static extern bool igCollapsingHeader(byte* label, TreeNodeFlags flags = 0);
         [DllImport(cimguiLib, CallingConvention = CallingConvention.Cdecl)]
         [return: MarshalAs(UnmanagedType.I1)]
-        public static extern bool igCollapsingHeaderEx(string label, ref bool p_open, TreeNodeFlags flags = 0);
+        public static extern bool igCollapsingHeaderEx(byte* label, ref bool p_open, TreeNodeFlags flags = 0);
 
         // Widgets: Selectable / Lists
         [DllImport(cimguiLib, CallingConvention = CallingConvention.Cdecl)]
         [return: MarshalAs(UnmanagedType.I1)]
-        public static extern bool igSelectable(string label, bool selected, SelectableFlags flags, Vector2 size);
+        public static extern bool igSelectable(byte* label, bool selected, SelectableFlags flags, Vector2 size);
         [DllImport(cimguiLib, CallingConvention = CallingConvention.Cdecl)]
         [return: MarshalAs(UnmanagedType.I1)]
-        public static extern bool igSelectableEx(string label, ref bool p_selected, SelectableFlags flags, Vector2 size);
+        public static extern bool igSelectableEx(byte* label, ref bool p_selected, SelectableFlags flags, Vector2 size);
         [DllImport(cimguiLib, CallingConvention = CallingConvention.Cdecl)]
         [return: MarshalAs(UnmanagedType.I1)]
-        public static extern bool igListBox(string label, int* current_item, char** items, int items_count, int height_in_items);
+        public static extern bool igListBox(byte* label, int* current_item, char** items, int items_count, int height_in_items);
 
         [DllImport(cimguiLib, CallingConvention = CallingConvention.Cdecl)]
         [return: MarshalAs(UnmanagedType.I1)]
-        public static extern bool igListBox2(string label, ref int currentItem, ItemSelectedCallback items_getter, IntPtr data, int items_count, int height_in_items);
+        public static extern bool igListBox2(byte* label, ref int currentItem, ItemSelectedCallback items_getter, IntPtr data, int items_count, int height_in_items);
 
         [DllImport(cimguiLib, CallingConvention = CallingConvention.Cdecl)]
         [return: MarshalAs(UnmanagedType.I1)]
-        public static extern bool igListBoxHeader(string label, Vector2 size);
+        public static extern bool igListBoxHeader(byte* label, Vector2 size);
         [DllImport(cimguiLib, CallingConvention = CallingConvention.Cdecl)]
         [return: MarshalAs(UnmanagedType.I1)]
-        public static extern bool igListBoxHeader2(string label, int items_count, int height_in_items);
+        public static extern bool igListBoxHeader2(byte* label, int items_count, int height_in_items);
         [DllImport(cimguiLib, CallingConvention = CallingConvention.Cdecl)]
         public static extern void igListBoxFooter();
 
@@ -566,7 +566,7 @@ namespace ImGuiNET
 
         // Tooltip
         [DllImport(cimguiLib, CallingConvention = CallingConvention.Cdecl)]
-        public static extern void igSetTooltip(string fmt);
+        public static extern void igSetTooltip(byte* fmt);
         [DllImport(cimguiLib, CallingConvention = CallingConvention.Cdecl)]
         public static extern void igBeginTooltip();
         [DllImport(cimguiLib, CallingConvention = CallingConvention.Cdecl)]
@@ -585,15 +585,15 @@ namespace ImGuiNET
         public static extern void igEndMenuBar();
         [DllImport(cimguiLib, CallingConvention = CallingConvention.Cdecl)]
         [return: MarshalAs(UnmanagedType.I1)]
-        public static extern bool igBeginMenu(string label, bool enabled);
+        public static extern bool igBeginMenu(byte* label, bool enabled);
         [DllImport(cimguiLib, CallingConvention = CallingConvention.Cdecl)]
         public static extern void igEndMenu();
         [DllImport(cimguiLib, CallingConvention = CallingConvention.Cdecl)]
         [return: MarshalAs(UnmanagedType.I1)]
-        public static extern bool igMenuItem(string label, string shortcut, bool selected, bool enabled);
+        public static extern bool igMenuItem(byte* label, string shortcut, bool selected, bool enabled);
         [DllImport(cimguiLib, CallingConvention = CallingConvention.Cdecl)]
         [return: MarshalAs(UnmanagedType.I1)]
-        public static extern bool igMenuItemPtr(string label, string shortcut, bool* p_selected, bool enabled);
+        public static extern bool igMenuItemPtr(byte* label, string shortcut, bool* p_selected, bool enabled);
 
         // Popup
         [DllImport(cimguiLib, CallingConvention = CallingConvention.Cdecl)]
@@ -606,7 +606,7 @@ namespace ImGuiNET
         public static extern bool igBeginPopup(string str_id);
         [DllImport(cimguiLib, CallingConvention = CallingConvention.Cdecl)]
         [return: MarshalAs(UnmanagedType.I1)]
-        public static extern bool igBeginPopupModal(string name, byte* p_opened, WindowFlags extra_flags);
+        public static extern bool igBeginPopupModal(byte* name, byte* p_opened, WindowFlags extra_flags);
 
         [DllImport(cimguiLib, CallingConvention = CallingConvention.Cdecl)]
         [return: MarshalAs(UnmanagedType.I1)]
@@ -620,7 +620,7 @@ namespace ImGuiNET
         [DllImport(cimguiLib, CallingConvention = CallingConvention.Cdecl)]
         public static extern void igEndPopup();
         [DllImport(cimguiLib, CallingConvention = CallingConvention.Cdecl)]
-        public static extern bool igIsPopupOpen(string str_id);
+        public static extern bool igIsPopupOpen(byte* str_id);
         [DllImport(cimguiLib, CallingConvention = CallingConvention.Cdecl)]
         public static extern void igCloseCurrentPopup();
 
@@ -802,9 +802,9 @@ namespace ImGuiNET
         [DllImport(cimguiLib, CallingConvention = CallingConvention.Cdecl)]
         public static extern void igMemFree(void* ptr);
         [DllImport(cimguiLib, CallingConvention = CallingConvention.Cdecl)]
-        public static extern string igGetClipboardText();
+        public static extern byte* igGetClipboardText();
         [DllImport(cimguiLib, CallingConvention = CallingConvention.Cdecl)]
-        public static extern void igSetClipboardText(string text);
+        public static extern void igSetClipboardText(byte* text);
 
         // public state access - if you want to share ImGui state between modules (e.g. DLL) or allocate it yourself
         [DllImport(cimguiLib, CallingConvention = CallingConvention.Cdecl)]

--- a/src/ImGui.NET/ImGuiNative.cs
+++ b/src/ImGui.NET/ImGuiNative.cs
@@ -836,30 +836,30 @@ namespace ImGuiNET
         public static NativeFont* ImFontAtlas_AddFontDefault(NativeFontAtlas* atlas) { return ImFontAtlas_AddFontDefault(atlas, IntPtr.Zero); }
 
         [DllImport(cimguiLib, CallingConvention = CallingConvention.Cdecl)]
-        public static extern NativeFont* ImFontAtlas_AddFontFromFileTTF(NativeFontAtlas* atlas, string filename, float size_pixels, IntPtr font_cfg, char* glyph_ranges);
+        public static extern NativeFont* ImFontAtlas_AddFontFromFileTTF(NativeFontAtlas* atlas, string filename, float size_pixels, IntPtr font_cfg, ushort* glyph_ranges);
         [DllImport(cimguiLib, CallingConvention = CallingConvention.Cdecl)]
-        public static extern NativeFont* ImFontAtlas_AddFontFromMemoryTTF(NativeFontAtlas* atlas, void* ttf_data, int ttf_size, float size_pixels, IntPtr font_cfg, char* glyph_ranges);
+        public static extern NativeFont* ImFontAtlas_AddFontFromMemoryTTF(NativeFontAtlas* atlas, void* ttf_data, int ttf_size, float size_pixels, IntPtr font_cfg, ushort* glyph_ranges);
         [DllImport(cimguiLib, CallingConvention = CallingConvention.Cdecl)]
-        public static extern NativeFont* ImFontAtlas_AddFontFromMemoryCompressedTTF(NativeFontAtlas* atlas, void* compressed_ttf_data, int compressed_ttf_size, float size_pixels, FontConfig* font_cfg, char* glyph_ranges);
+        public static extern NativeFont* ImFontAtlas_AddFontFromMemoryCompressedTTF(NativeFontAtlas* atlas, void* compressed_ttf_data, int compressed_ttf_size, float size_pixels, FontConfig* font_cfg, ushort* glyph_ranges);
         [DllImport(cimguiLib, CallingConvention = CallingConvention.Cdecl)]
-        public static extern NativeFont* ImFontAtlas_AddFontFromMemoryCompressedBase85TTF(NativeFontAtlas* atlas, string compressed_ttf_data_base85, float size_pixels, FontConfig* font_cfg, char* glyph_ranges);
+        public static extern NativeFont* ImFontAtlas_AddFontFromMemoryCompressedBase85TTF(NativeFontAtlas* atlas, string compressed_ttf_data_base85, float size_pixels, FontConfig* font_cfg, ushort* glyph_ranges);
 
         [DllImport(cimguiLib, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ImFontAtlas_ClearTexData(NativeFontAtlas* atlas);
         [DllImport(cimguiLib, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ImFontAtlas_Clear(NativeFontAtlas* atlas);
         [DllImport(cimguiLib, CallingConvention = CallingConvention.Cdecl)]
-        public static extern char* ImFontAtlas_GetGlyphRangesDefault(NativeFontAtlas* atlas);
+        public static extern ushort* ImFontAtlas_GetGlyphRangesDefault(NativeFontAtlas* atlas);
         [DllImport(cimguiLib, CallingConvention = CallingConvention.Cdecl)]
-        public static extern char* ImFontAtlas_GetGlyphRangesKorean(NativeFontAtlas* atlas);
+        public static extern ushort* ImFontAtlas_GetGlyphRangesKorean(NativeFontAtlas* atlas);
         [DllImport(cimguiLib, CallingConvention = CallingConvention.Cdecl)]
-        public static extern char* ImFontAtlas_GetGlyphRangesJapanese(NativeFontAtlas* atlas);
+        public static extern ushort* ImFontAtlas_GetGlyphRangesJapanese(NativeFontAtlas* atlas);
         [DllImport(cimguiLib, CallingConvention = CallingConvention.Cdecl)]
-        public static extern char* ImFontAtlas_GetGlyphRangesChinese(NativeFontAtlas* atlas);
+        public static extern ushort* ImFontAtlas_GetGlyphRangesChinese(NativeFontAtlas* atlas);
         [DllImport(cimguiLib, CallingConvention = CallingConvention.Cdecl)]
-        public static extern char* ImFontAtlas_GetGlyphRangesCyrillic(NativeFontAtlas* atlas);
+        public static extern ushort* ImFontAtlas_GetGlyphRangesCyrillic(NativeFontAtlas* atlas);
         [DllImport(cimguiLib, CallingConvention = CallingConvention.Cdecl)]
-        public static extern char* ImFontAtlas_GetGlyphRangesThai(NativeFontAtlas* atlas);
+        public static extern ushort* ImFontAtlas_GetGlyphRangesThai(NativeFontAtlas* atlas);
 
         [DllImport(cimguiLib, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ImGuiIO_AddInputCharacter(ushort c);

--- a/src/ImGui.NET/Utf8Buffer.cs
+++ b/src/ImGui.NET/Utf8Buffer.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace ImGuiNET
+{
+    public unsafe class Utf8Buffer
+    {
+        private const int BufferSize = 4 * 1024 * 20;  //20k utf8 chars at least
+        private GCHandle _pinnedArray;
+        private readonly IntPtr _memPtr;
+        private readonly byte[] _arrayBuffer;
+        private int _usedBytes;
+
+        public Utf8Buffer()
+        {
+            _arrayBuffer = new byte[BufferSize];
+            _pinnedArray = GCHandle.Alloc(_arrayBuffer, GCHandleType.Pinned);
+            _memPtr = _pinnedArray.AddrOfPinnedObject();
+        }
+
+        //reset buffer position and make sure that any pointer into it will result in null-terminated string
+        public void Reset()
+        {
+            _usedBytes = 0;
+            _arrayBuffer[0] = 0;
+            _arrayBuffer[BufferSize - 1] = 0;
+        }
+
+        public byte* FromStr(string str)
+        {
+            byte* dest = (byte*)_memPtr;
+            //If the maximum possible string length doesn't fit our buffer, just return an empty string.
+            //Probly some message like <Utf8Buffer: couldn't convert text> would be better, so user knows what happened
+            //If _usedBytes equals 0, we could also re-allocate the buffer
+            var maxBytes = Encoding.UTF8.GetMaxByteCount(str.Length) + 1;
+            if (BufferSize < maxBytes)
+            {
+                Reset();
+                return dest;
+            }
+
+            //Wrap if it's possible that the string won't fit. 
+            //This is ok, assuming one ImGui call doesn't use longer strings (sum of their utf8 byte lengths) that would fit into our buffer.
+            if (BufferSize < _usedBytes + maxBytes)
+            {
+                Reset();
+            }
+
+            dest += _usedBytes;
+            int byteCount = Encoding.UTF8.GetBytes(str, 0, str.Length, _arrayBuffer, _usedBytes);
+            dest[byteCount] = 0;
+            _usedBytes += byteCount + 1;
+
+            return dest;
+        }
+
+        public string ToStr(byte* b)
+        {
+            if (b == null)
+                return string.Empty;
+            int length = 0;
+            while (b[length] != '\0')
+                length++;
+
+            Marshal.Copy((IntPtr)b, _arrayBuffer, 0, length);
+            return Encoding.UTF8.GetString(_arrayBuffer, 0, length);
+        }
+    }
+}


### PR DESCRIPTION
Modifications needed for proper utf-8 string handling (based on discussion in issue #7) 
* native calls use byte pointer instead of string in parameters
* ImGui class methods handle the conversion calls from string to utf-8 (and the reverse in some rare cases)
* Utf8Buffer uses a static buffer for conversions, so no additional memory allocations are needed. ImGui uses a 3kB buffer for string parameter handling, Utf8Buffer allocates much more to safely handle functions with multiple string parameters - 80kB as of now, this can be safely reduced as there aren't many such functions
* changed type of glyph range params to ushort* to allow for numeric ranges (as imgui does)