### PR TITLE
Minor additions and important bug fix in ImGui.GetIO()

### DIFF
--- a/src/ImGui.NET/IO.cs
+++ b/src/ImGui.NET/IO.cs
@@ -265,6 +265,12 @@ namespace ImGuiNET
             return new Font(nativeFontPtr);
         }
 
+        public Font AddDefaultFont(FontConfig cfg)
+        {
+            NativeFont* nativeFontPtr = ImGuiNative.ImFontAtlas_AddFontDefault(_atlasPtr, new IntPtr(&cfg));
+            return new Font(nativeFontPtr);
+        }
+
         public Font AddFontFromFileTTF(string fileName, float pixelSize)
         {
             NativeFont* nativeFontPtr = ImGuiNative.ImFontAtlas_AddFontFromFileTTF(_atlasPtr, fileName, pixelSize, IntPtr.Zero, null);

--- a/src/ImGui.NET/ImGui.cs
+++ b/src/ImGui.NET/ImGui.cs
@@ -34,7 +34,7 @@ namespace ImGuiNET
         public static void PushID(string id)
         {
             ImGuiNative.igPushIDStr(id);
-        }
+		}
 
         public static void PushID(object id)
         {

--- a/src/ImGui.NET/ImGui.cs
+++ b/src/ImGui.NET/ImGui.cs
@@ -22,9 +22,10 @@ namespace ImGuiNET
             ImGuiNative.igShutdown();
         }
 
-        private static unsafe readonly IO s_io = new IO(ImGuiNative.igGetIO());
+        //private static unsafe readonly IO s_io = new IO(ImGuiNative.igGetIO());
 
-        public static unsafe IO GetIO() => s_io;
+        //public static unsafe IO GetIO() => s_io;
+        public static unsafe IO GetIO() => new IO(ImGuiNative.igGetIO());
 
         private static unsafe readonly Style s_style = new Style(ImGuiNative.igGetStyle());
 
@@ -36,6 +37,11 @@ namespace ImGuiNET
         public static void PushID(string id)
         {
             ImGuiNative.igPushIDStr(id);
+        }
+
+        public static void PushID(object id)
+        {
+            PushID(id?.GetHashCode() ?? 0);
         }
 
         public static void PushID(int id)
@@ -76,6 +82,11 @@ namespace ImGuiNET
         public static void Text(string message)
         {
             ImGuiNative.igText(message);
+        }
+
+        public static void Text(string format, params object[] args)
+        {
+            ImGuiNative.igText(string.Format(format, args));
         }
 
         public static void Text(string message, Vector4 color)
@@ -122,7 +133,7 @@ namespace ImGuiNET
         {
             return ImGuiNative.igInvisibleButton(id, size);
         }
-
+        
         public static void Image(IntPtr userTextureID, Vector2 size, Vector2 uv0, Vector2 uv1, Vector4 tintColor, Vector4 borderColor)
         {
             ImGuiNative.igImage(userTextureID, size, uv0, uv1, tintColor, borderColor);

--- a/src/ImGui.NET/ImGui.cs
+++ b/src/ImGui.NET/ImGui.cs
@@ -21,10 +21,7 @@ namespace ImGuiNET
         {
             ImGuiNative.igShutdown();
         }
-
-        //private static unsafe readonly IO s_io = new IO(ImGuiNative.igGetIO());
-
-        //public static unsafe IO GetIO() => s_io;
+        
         public static unsafe IO GetIO() => new IO(ImGuiNative.igGetIO());
 
         private static unsafe readonly Style s_style = new Style(ImGuiNative.igGetStyle());


### PR DESCRIPTION
I added some useful functions, also fixed a Bug in `ImGui.GetIO()`:

When using multiple contexts, the IO structure changes per context and must not be cached in order to adapt to work with `ImGui::SetContext`