### PR TITLE
Updated to MonoGame 3.7

### DIFF
--- a/src/ImGui.NET.SampleProgram.XNA/ImGui.NET.SampleProgram.XNA.csproj
+++ b/src/ImGui.NET.SampleProgram.XNA/ImGui.NET.SampleProgram.XNA.csproj
@@ -20,7 +20,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.6.0.1625" />
+      <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.7.0.1708" />
     </ItemGroup>
 
 </Project>

--- a/src/ImGui.NET.SampleProgram.XNA/Program.cs
+++ b/src/ImGui.NET.SampleProgram.XNA/Program.cs
@@ -4,7 +4,7 @@
     {
         public static void Main(string[] args)
         {
-            new SampleGame().Run();
+            using (var game = new SampleGame()) game.Run();
         }
     }
 }


### PR DESCRIPTION
Updates the MonoGame sample to 3.7. Also fixes a problem causing the app to hang on exit.