### PR TITLE
Fix non '\0' terminated labels for InputText

### DIFF
--- a/src/ImGui.NET/ImGui.Manual.cs
+++ b/src/ImGui.NET/ImGui.Manual.cs
@@ -44,7 +44,7 @@ namespace ImGuiNET
         {
 
             int labelByteCount = Encoding.UTF8.GetByteCount(label);
-            byte* labelBytes = stackalloc byte[labelByteCount];
+            byte* labelBytes = stackalloc byte[labelByteCount + 1];
             fixed (char* labelPtr = label)
             {
                 Encoding.UTF8.GetBytes(labelPtr, label.Length, labelBytes, labelByteCount);
@@ -83,7 +83,7 @@ namespace ImGuiNET
             IntPtr user_data)
         {
             int labelByteCount = Encoding.UTF8.GetByteCount(label);
-            byte* labelBytes = stackalloc byte[labelByteCount];
+            byte* labelBytes = stackalloc byte[labelByteCount + 1];
             fixed (char* labelPtr = label)
             {
                 Encoding.UTF8.GetBytes(labelPtr, label.Length, labelBytes, labelByteCount);
@@ -146,7 +146,7 @@ namespace ImGuiNET
             IntPtr user_data)
         {
             int labelByteCount = Encoding.UTF8.GetByteCount(label);
-            byte* labelBytes = stackalloc byte[labelByteCount];
+            byte* labelBytes = stackalloc byte[labelByteCount + 1];
             fixed (char* labelPtr = label)
             {
                 Encoding.UTF8.GetBytes(labelPtr, label.Length, labelBytes, labelByteCount);
@@ -216,7 +216,7 @@ namespace ImGuiNET
         {
 
             int labelByteCount = Encoding.UTF8.GetByteCount(label);
-            byte* labelBytes = stackalloc byte[labelByteCount];
+            byte* labelBytes = stackalloc byte[labelByteCount + 1];
             fixed (char* labelPtr = label)
             {
                 Encoding.UTF8.GetBytes(labelPtr, label.Length, labelBytes, labelByteCount);


### PR DESCRIPTION
I extended the byte arrays for the labels of the InputText functions by one byte to ensure that there is always a 0 at the end. Previously only the length of the label was allocated. As .net is initializing arrays with 0 and (at least for this stackalloc here) this happens in 4-byte chunks only strings with a length multiple of 4 were affected as in this case the allocated size exactly matched the length of the string and so no 0 was left to be used for string end. Now the array is generated always one byte larger than the label length, so there will always be a 0 at the end.

Before when using an InputText where the label had a length multiple of 4 this happened (here the label was "ABCD"):
![image](https://user-images.githubusercontent.com/2141927/49612106-ec0c1380-f9a3-11e8-8a04-7fe67ebc7860.png)
