### PR TITLE
.gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,7 +48,6 @@ dlldata.c
 *_i.h
 *.ilk
 *.meta
-*.obj
 *.pch
 *.pdb
 *.pgc


### PR DESCRIPTION
Tog bort '*.obj'. Vilket gör att vi kan synka .obj filer