### PR TITLE
Update dependencies and fix MonoGame blur issue

### DIFF
--- a/src/CodeGenerator/CodeGenerator.csproj
+++ b/src/CodeGenerator/CodeGenerator.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
 
 </Project>

--- a/src/ImGui.NET.SampleProgram.XNA/ImGui.NET.SampleProgram.XNA.csproj
+++ b/src/ImGui.NET.SampleProgram.XNA/ImGui.NET.SampleProgram.XNA.csproj
@@ -20,7 +20,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.7.0.1708" />
+      <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.0.1641" />
     </ItemGroup>
 
 </Project>

--- a/src/ImGui.NET.SampleProgram.XNA/ImGuiRenderer.cs
+++ b/src/ImGui.NET.SampleProgram.XNA/ImGuiRenderer.cs
@@ -195,17 +195,9 @@ namespace ImGuiNET.SampleProgram.XNA
 
             var io = ImGui.GetIO();
 
-            // MonoGame-specific //////////////////////
-            var offset = .5f;
-            ///////////////////////////////////////////
-
-            // FNA-specific ///////////////////////////
-            //var offset = 0f;
-            ///////////////////////////////////////////
-
             _effect.World = Matrix.Identity;
             _effect.View = Matrix.Identity;
-            _effect.Projection = Matrix.CreateOrthographicOffCenter(offset, io.DisplaySize.X + offset, io.DisplaySize.Y + offset, offset, -1f, 1f);
+            _effect.Projection = Matrix.CreateOrthographicOffCenter(0f, io.DisplaySize.X, io.DisplaySize.Y, 0f, -1f, 1f);
             _effect.TextureEnabled = true;
             _effect.Texture = texture;
             _effect.VertexColorEnabled = true;

--- a/src/ImGui.NET.SampleProgram/ImGui.NET.SampleProgram.csproj
+++ b/src/ImGui.NET.SampleProgram/ImGui.NET.SampleProgram.csproj
@@ -8,8 +8,8 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ImGui.NET\ImGui.NET.csproj" />
-    <PackageReference Include="Veldrid" Version="4.3.3" />
-    <PackageReference Include="Veldrid.StartupUtilities" Version="4.3.3" />
+    <PackageReference Include="Veldrid" Version="4.8.0" />
+    <PackageReference Include="Veldrid.StartupUtilities" Version="4.8.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ImGui.NET/ImGui.NET.csproj
+++ b/src/ImGui.NET/ImGui.NET.csproj
@@ -16,9 +16,9 @@
     <RootNamespace>ImGuiNET</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="System.Numerics.Vectors" Version="4.4.0" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.4.0" />
-    <PackageReference Include="System.Buffers" Version="4.4.0" />
+    <PackageReference Include="System.Numerics.Vectors" Version="4.6.0-preview4.19164.7" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="5.0.0-rc.1.20451.14" />
+    <PackageReference Include="System.Buffers" Version="4.6.0-preview1-26912-03" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="..\..\deps\cimgui\win-x86\cimgui.dll">


### PR DESCRIPTION
- ImGui.NET.SampleProgram was barfing with an exception, fixed that by updating deps
- Updated to MonoGame version 3.8 and fixed blur by removing the offset which isn't required anymore (closes: https://github.com/mellinoe/ImGui.NET/issues/97)
- Updated misc deps while I was fixing above things