### PR TITLE
Fix vertex/index buffer offset handling in sample programs, fix modals in XNA

### DIFF
--- a/src/ImGui.NET.SampleProgram.XNA/ImGuiRenderer.cs
+++ b/src/ImGui.NET.SampleProgram.XNA/ImGuiRenderer.cs
@@ -339,6 +339,11 @@ namespace ImGuiNET.SampleProgram.XNA
                 {
                     ImDrawCmdPtr drawCmd = cmdList.CmdBuffer[cmdi];
 
+                    if (drawCmd.ElemCount == 0) 
+                    {
+                        continue;
+                    }
+
                     if (!_loadedTextures.ContainsKey(drawCmd.TextureId))
                     {
                         throw new InvalidOperationException($"Could not find a texture with id '{drawCmd.TextureId}', please check your bindings");
@@ -360,19 +365,18 @@ namespace ImGuiNET.SampleProgram.XNA
 #pragma warning disable CS0618 // // FNA does not expose an alternative method.
                         _graphicsDevice.DrawIndexedPrimitives(
                             primitiveType: PrimitiveType.TriangleList,
-                            baseVertex: vtxOffset,
+                            baseVertex: (int)drawCmd.VtxOffset + vtxOffset,
                             minVertexIndex: 0,
                             numVertices: cmdList.VtxBuffer.Size,
-                            startIndex: idxOffset,
+                            startIndex: (int)drawCmd.IdxOffset + idxOffset,
                             primitiveCount: (int)drawCmd.ElemCount / 3
                         );
 #pragma warning restore CS0618
                     }
-
-                    idxOffset += (int)drawCmd.ElemCount;
                 }
 
                 vtxOffset += cmdList.VtxBuffer.Size;
+                idxOffset += cmdList.IdxBuffer.Size;
             }
         }
 

--- a/src/ImGui.NET.SampleProgram/ImGuiController.cs
+++ b/src/ImGui.NET.SampleProgram/ImGuiController.cs
@@ -520,12 +520,11 @@ namespace ImGuiNET
                             (uint)(pcmd.ClipRect.Z - pcmd.ClipRect.X),
                             (uint)(pcmd.ClipRect.W - pcmd.ClipRect.Y));
 
-                        cl.DrawIndexed(pcmd.ElemCount, 1, (uint)idx_offset, vtx_offset, 0);
+                        cl.DrawIndexed(pcmd.ElemCount, 1, pcmd.IdxOffset + (uint)idx_offset, (int)pcmd.VtxOffset + vtx_offset, 0);
                     }
-
-                    idx_offset += (int)pcmd.ElemCount;
                 }
                 vtx_offset += cmd_list.VtxBuffer.Size;
+                idx_offset += cmd_list.IdxBuffer.Size;
             }
         }
 


### PR DESCRIPTION
Recently the rendering logic in ImGui was modified making it so that the approach of manually calculating idx_offset would produce incorrect results, instead having to rely on the provided IdxOffset property from the draw commands. 

This issue is referenced in:
- https://github.com/ocornut/imgui/issues/4863
- https://github.com/ocornut/imgui/issues/4845
- https://github.com/ocornut/imgui/issues/4887

A fix for OpenGL2 is shown in https://github.com/ocornut/imgui/issues/4845#issuecomment-1003329113. This also modifies the vertex buffer offset in a similar way, as referenced in #244.

Modal windows don't work in XNA-derived frameworks and will immediately crash the application. This happens because opening a modal window can issue draw commands with an element count of 0, and a check in the DrawIndexedPrimitives function throws an exception in these situations. This is fixed by simply ignoring those commands and continuing to the next one in the list. 

This isn't limited to modals, however, as referenced in https://github.com/ocornut/imgui/issues/4857, draw calls from draw lists can cause this to happen as well. The same fix for the Metal backend is used here.

These changes have only been tested in Monogame, but they should work in FNA all the same.