### PR TITLE
Linked the src folder in readme to show the location of examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ ImGui.NET can be built in Visual Studio or on the command line. The .NET Core SD
 
 # Usage
 
-ImGui.NET currently provides a raw wrapper around the ImGui native API, and also provides a very thin safe, managed API for convenience. It is currently very much like using the native library, which is very simple, flexible, and robust. The easiest way to figure out how to use the library is to read the documentation of imgui itself, mostly in the imgui.cpp, and imgui.h files, as well as the exported functions in cimgui.h. Looking at the sample program code will also give some indication about basic usage.
+ImGui.NET currently provides a raw wrapper around the ImGui native API, and also provides a very thin safe, managed API for convenience. It is currently very much like using the native library, which is very simple, flexible, and robust. The easiest way to figure out how to use the library is to read the documentation of imgui itself, mostly in the imgui.cpp, and imgui.h files, as well as the exported functions in cimgui.h. Looking at the [sample program code](https://github.com/mellinoe/ImGui.NET/tree/master/src) will also give some indication about basic usage.
 
 # Debugging native code
 


### PR DESCRIPTION
I spent over 6 hours of dumb searching over the internet and debugging, just because I assumed the only available example is at the new-demo branch. I am running Monogame, so this example is far from perfect for my case. I was expecting the library code to be in the `src/`, and completely disregarded the directory. While it's definitely my fault, I believe that this change may help other absent minded individuals.