### PR TITLE
adding back the .netstandard2.0

### DIFF
--- a/src/CodeGenerator/CodeGenerator.csproj
+++ b/src/CodeGenerator/CodeGenerator.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/ImGui.NET/ImGui.NET.csproj
+++ b/src/ImGui.NET/ImGui.NET.csproj
@@ -3,7 +3,7 @@
     <Description>A .NET wrapper for the Dear ImGui library.</Description>
     <AssemblyVersion>1.87.2</AssemblyVersion>
     <Authors>Eric Mellino</Authors>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DebugType>portable</DebugType>
     <AssemblyName>ImGui.NET</AssemblyName>

--- a/src/ImGuizmo.NET/ImGuizmo.NET.csproj
+++ b/src/ImGuizmo.NET/ImGuizmo.NET.csproj
@@ -3,7 +3,7 @@
     <Description>A .NET wrapper for the ImGuizmo library.</Description>
     <AssemblyVersion>1.61.0</AssemblyVersion>
     <Authors>Eric Mellino</Authors>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DebugType>portable</DebugType>
     <AssemblyName>ImGuizmo.NET</AssemblyName>

--- a/src/ImNodes.NET/ImNodes.NET.csproj
+++ b/src/ImNodes.NET/ImNodes.NET.csproj
@@ -3,7 +3,7 @@
     <Description>A .NET wrapper for the imnodes library.</Description>
     <AssemblyVersion>0.3.0</AssemblyVersion>
     <Authors>Eric Mellino</Authors>
-	  <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DebugType>portable</DebugType>
     <AssemblyName>ImNodes.NET</AssemblyName>

--- a/src/ImPlot.NET/ImPlot.NET.csproj
+++ b/src/ImPlot.NET/ImPlot.NET.csproj
@@ -3,7 +3,7 @@
     <Description>A .NET wrapper for the ImPlot library.</Description>
     <AssemblyVersion>0.8.0</AssemblyVersion>
     <Authors>Eric Mellino</Authors>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DebugType>portable</DebugType>
     <AssemblyName>ImPlot.NET</AssemblyName>


### PR DESCRIPTION
I still think that .net6 isn't really required for ImGui.NET library, .netstandard is more than enough (unless we want to use new c# language features that are added in .net6). However, I have no way of testing this (do not have the latest macbook). So, I have added back .netstandard2.0 and didn't remove .net6.


Ref1: https://docs.microsoft.com/en-us/dotnet/standard/net-standard?tabs=net-standard-2-0#net-standard-not-deprecated
Ref2: https://docs.microsoft.com/en-us/dotnet/standard/net-standard?tabs=net-standard-2-0#when-to-target-net50-or-net60-vs-netstandard