### PR TITLE
Fixed small bug in null-terminated string counting

### DIFF
--- a/src/ImGui.NET.SampleProgram/ImGuiController.cs
+++ b/src/ImGui.NET.SampleProgram/ImGuiController.cs
@@ -228,7 +228,7 @@ namespace ImGuiNET
             int count = 0;
             while (titlePtr[count] != 0)
             {
-                titlePtr += 1;
+                count += 1;
             }
             window.Window.Title = System.Text.Encoding.ASCII.GetString(titlePtr, count);
         }


### PR DESCRIPTION
Small fix in the ImGuiController of the docking sample, miscounting null-terminated strings.