### PR TITLE
Fixed AddConvexPolyFilled and AddPolyLine parameters

### DIFF
--- a/src/ImGui.NET/Generated/ImDrawList.gen.cs
+++ b/src/ImGui.NET/Generated/ImDrawList.gen.cs
@@ -134,9 +134,9 @@ namespace ImGuiNET
         {
             ImGuiNative.ImDrawList_AddCircleFilled((ImDrawList*)(NativePtr), center, radius, col, num_segments);
         }
-        public void AddConvexPolyFilled(ref Vector2 points, int num_points, uint col)
+        public void AddConvexPolyFilled(Vector2[] points, int num_points, uint col)
         {
-            fixed (Vector2* native_points = &points)
+            fixed (Vector2* native_points = points)
             {
                 ImGuiNative.ImDrawList_AddConvexPolyFilled((ImDrawList*)(NativePtr), native_points, num_points, col);
             }
@@ -237,9 +237,9 @@ namespace ImGuiNET
         {
             ImGuiNative.ImDrawList_AddNgonFilled((ImDrawList*)(NativePtr), center, radius, col, num_segments);
         }
-        public void AddPolyline(ref Vector2 points, int num_points, uint col, ImDrawFlags flags, float thickness)
+        public void AddPolyline(Vector2[] points, int num_points, uint col, ImDrawFlags flags, float thickness)
         {
-            fixed (Vector2* native_points = &points)
+            fixed (Vector2* native_points = points)
             {
                 ImGuiNative.ImDrawList_AddPolyline((ImDrawList*)(NativePtr), native_points, num_points, col, flags, thickness);
             }


### PR DESCRIPTION
Changed params from 
`ref Vector2`
to array
`Vector2[]`

Fixed result:
![convexpolyfilled and polyline png](https://user-images.githubusercontent.com/70348218/182983869-11184072-0f9b-4d96-9ff4-7c054ce71367.png)

previous result: (could only pass single vec2)
![convexpoly and polyline - Current](https://user-images.githubusercontent.com/70348218/182983875-ecd7eba5-0e9b-4e5d-a396-d79ab38166b3.png)

