### PR TITLE
fix: scripts and targets after #318

### DIFF
--- a/download-native-deps.ps1
+++ b/download-native-deps.ps1
@@ -15,7 +15,7 @@ if (Test-Path $PSScriptRoot\deps\cimgui\)
     Remove-Item $PSScriptRoot\deps\cimgui\ -Force -Recurse | Out-Null
 }
 New-Item -ItemType Directory -Force -Path $PSScriptRoot\deps\cimgui\linux-x64 | Out-Null
-New-Item -ItemType Directory -Force -Path $PSScriptRoot\deps\cimgui\osx-universal | Out-Null
+New-Item -ItemType Directory -Force -Path $PSScriptRoot\deps\cimgui\osx | Out-Null
 New-Item -ItemType Directory -Force -Path $PSScriptRoot\deps\cimgui\win-x86 | Out-Null
 New-Item -ItemType Directory -Force -Path $PSScriptRoot\deps\cimgui\win-x64 | Out-Null
 
@@ -60,7 +60,7 @@ Write-Host - cimgui.so
 
 $client.DownloadFile(
     "$repository/releases/download/$tag/cimgui.dylib",
-    "$PSScriptRoot/deps/cimgui/osx-universal/cimgui.dylib")
+    "$PSScriptRoot/deps/cimgui/osx/cimgui.dylib")
 if( -not $? )
 {
     $msg = $Error[0].Exception.Message

--- a/download-native-deps.sh
+++ b/download-native-deps.sh
@@ -24,8 +24,8 @@ echo -n "Downloading linux x64 cimgui: "
 curl -sfLo "$SCRIPT_ROOT/deps/cimgui/linux-x64/cimgui.so" "https://github.com/mellinoe/imgui.net-nativebuild/releases/download/$TAG/cimgui.so"
 echo ""
 
-echo -n "Downloading osx x64 cimgui: "
-curl -sfLo "$SCRIPT_ROOT/deps/cimgui/osx-x64/cimgui.dylib" "https://github.com/mellinoe/imgui.net-nativebuild/releases/download/$TAG/cimgui.dylib"
+echo -n "Downloading osx universal (x86_64 and arm64) cimgui: "
+curl -sfLo "$SCRIPT_ROOT/deps/cimgui/osx/cimgui.dylib" "https://github.com/mellinoe/imgui.net-nativebuild/releases/download/$TAG/cimgui.dylib"
 echo ""
 
 echo -n "Downloading definitions json file: "

--- a/src/ImGui.NET/build/net40/ImGui.NET.targets
+++ b/src/ImGui.NET/build/net40/ImGui.NET.targets
@@ -5,14 +5,14 @@
     <_IsMacOS Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX)))' == 'true'">true</_IsMacOS>
     <_IsLinux Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))' == 'true'">true</_IsLinux>
 
-    <_NativeRuntime Condition=" '$(_NativeRuntime)' == '' And '$(_IsMacOS)' == 'true' And '$(PlatformTarget)' == 'x64'">osx-x64</_NativeRuntime>
-    <_NativeRuntime Condition=" '$(_NativeRuntime)' == '' And '$(_IsMacOS)' == 'true' And '$(PlatformTarget)' == 'ARM64'">osx-arm64</_NativeRuntime>
+    <_NativeRuntime Condition=" '$(_NativeRuntime)' == '' And '$(_IsMacOS)' == 'true' And '$(PlatformTarget)' == 'x64'">osx</_NativeRuntime>
+    <_NativeRuntime Condition=" '$(_NativeRuntime)' == '' And '$(_IsMacOS)' == 'true' And '$(PlatformTarget)' == 'ARM64'">osx</_NativeRuntime>
     <_NativeRuntime Condition=" '$(_NativeRuntime)' == '' And '$(_IsLinux)' == 'true' And ('$(Prefer32Bit)' == 'false' Or '$(PlatformTarget)' == 'x64')">linux-x64</_NativeRuntime>
     <_NativeRuntime Condition=" '$(_NativeRuntime)' == '' And '$(_IsWindows)' == 'true' And ('$(Prefer32Bit)' == 'true' Or '$(PlatformTarget)' == 'x86')">win-x86</_NativeRuntime>
     <_NativeRuntime Condition=" '$(_NativeRuntime)' == '' And '$(_IsWindows)' == 'true' And ('$(Prefer32Bit)' == 'false' Or '$(PlatformTarget)' == 'x64')">win-x64</_NativeRuntime>
 
     <_NativeLibName Condition="'$(_NativeRuntime)' == 'win-x86' Or '$(_NativeRuntime)' == 'win-x64'">cimgui.dll</_NativeLibName>
-    <_NativeLibName Condition="'$(_NativeRuntime)' == 'osx-x64' Or '$(_NativeRuntime)' == 'osx-arm64'">libcimgui.dylib</_NativeLibName>
+    <_NativeLibName Condition="'$(_NativeRuntime)' == 'osx'">libcimgui.dylib</_NativeLibName>
     <_NativeLibName Condition="'$(_NativeRuntime)' == 'linux-x64'">libcimgui.so</_NativeLibName>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
This PR fix script that currently download native binaries for macOS to wrong folder.
Also fix target for .net framework, to use new location.

Related to #318