### PR TITLE
Prevent input in ImGui when the MonoGame window is inactive

### DIFF
--- a/src/ImGui.NET.SampleProgram.XNA/ImGuiRenderer.cs
+++ b/src/ImGui.NET.SampleProgram.XNA/ImGuiRenderer.cs
@@ -211,6 +211,8 @@ namespace ImGuiNET.SampleProgram.XNA
         /// </summary>
         protected virtual void UpdateInput()
         {
+            if (!_game.IsActive) return;
+            
             var io = ImGui.GetIO();
 
             var mouse = Mouse.GetState();


### PR DESCRIPTION
Checks if the monogame game is active (disabled when the window doesn't have focus) and prevents input in ImGui.

Fixes #156