### PR TITLE
MonoGame & FNA sample upgrade

### DIFF
--- a/src/ImGui.NET.SampleProgram.XNA/ImGui.NET.SampleProgram.XNA.csproj
+++ b/src/ImGui.NET.SampleProgram.XNA/ImGui.NET.SampleProgram.XNA.csproj
@@ -20,7 +20,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.1.303" />
+      <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.4" />
     </ItemGroup>
 
 </Project>

--- a/src/ImGui.NET.SampleProgram.XNA/ImGuiRenderer.cs
+++ b/src/ImGui.NET.SampleProgram.XNA/ImGuiRenderer.cs
@@ -10,15 +10,15 @@ namespace ImGuiNET.SampleProgram.XNA
     /// <summary>
     /// ImGui renderer for use with XNA-likes (FNA & MonoGame)
     /// </summary>
-    public class ImGuiRenderer
+    public class ImGuiRenderer : IDisposable
     {
-        private Game _game;
+        private readonly Game _game;
 
         // Graphics
-        private GraphicsDevice _graphicsDevice;
+        private readonly GraphicsDevice _graphicsDevice;
 
         private BasicEffect _effect;
-        private RasterizerState _rasterizerState;
+        private readonly RasterizerState _rasterizerState;
 
         private byte[] _vertexData;
         private VertexBuffer _vertexBuffer;
@@ -29,7 +29,7 @@ namespace ImGuiNET.SampleProgram.XNA
         private int _indexBufferSize;
 
         // Textures
-        private Dictionary<IntPtr, Texture2D> _loadedTextures;
+        private readonly Dictionary<IntPtr, Texture2D> _loadedTextures;
 
         private int _textureId;
         private IntPtr? _fontTextureId;
@@ -38,7 +38,9 @@ namespace ImGuiNET.SampleProgram.XNA
         private int _scrollWheelValue;
         private int _horizontalScrollWheelValue;
         private readonly float WHEEL_DELTA = 120;
-        private Keys[] _allKeys = Enum.GetValues<Keys>();
+        private readonly Keys[] _allKeys = Enum.GetValues<Keys>();
+
+        private bool _disposed;
 
         public ImGuiRenderer(Game game)
         {
@@ -63,6 +65,12 @@ namespace ImGuiNET.SampleProgram.XNA
             SetupInput();
         }
 
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
         #region ImGuiRenderer
 
         /// <summary>
@@ -81,6 +89,8 @@ namespace ImGuiNET.SampleProgram.XNA
             // Create and register the texture as an XNA texture
             var tex2d = new Texture2D(_graphicsDevice, width, height, false, SurfaceFormat.Color);
             tex2d.SetData(pixels);
+            tex2d.Name = "ImGui font atlas";
+            tex2d.Tag = "ImGui";
 
             // Should a texture already have been build previously, unbind it first so it can be deallocated
             if (_fontTextureId.HasValue) UnbindTexture(_fontTextureId.Value);
@@ -120,6 +130,9 @@ namespace ImGuiNET.SampleProgram.XNA
         {
             ImGui.GetIO().DeltaTime = (float)gameTime.ElapsedGameTime.TotalSeconds;
 
+            // Enable docking
+            ImGui.GetIO().ConfigFlags |= ImGuiConfigFlags.DockingEnable;
+
             UpdateInput();
 
             ImGui.NewFrame();
@@ -144,24 +157,12 @@ namespace ImGuiNET.SampleProgram.XNA
         /// </summary>
         protected virtual void SetupInput()
         {
-            var io = ImGui.GetIO();
-
             // MonoGame-specific //////////////////////
-            _game.Window.TextInput += (s, a) =>
-            {
-                if (a.Character == '\t') return;
-                io.AddInputCharacter(a.Character);
-            };
-
+            _game.Window.TextInput += OnTextInput;
             ///////////////////////////////////////////
 
             // FNA-specific ///////////////////////////
-            //TextInputEXT.TextInput += c =>
-            //{
-            //    if (c == '\t') return;
-
-            //    ImGui.GetIO().AddInputCharacter(c);
-            //};
+            // TextInputEXT.TextInput += OnTextInput;
             ///////////////////////////////////////////
         }
 
@@ -170,7 +171,7 @@ namespace ImGuiNET.SampleProgram.XNA
         /// </summary>
         protected virtual Effect UpdateEffect(Texture2D texture)
         {
-            _effect = _effect ?? new BasicEffect(_graphicsDevice);
+            _effect ??= new BasicEffect(_graphicsDevice);
 
             var io = ImGui.GetIO();
 
@@ -180,6 +181,8 @@ namespace ImGuiNET.SampleProgram.XNA
             _effect.TextureEnabled = true;
             _effect.Texture = texture;
             _effect.VertexColorEnabled = true;
+            _effect.Name = $"{texture.Name}_effect";
+            _effect.Tag = "ImGui";
 
             return _effect;
         }
@@ -190,7 +193,7 @@ namespace ImGuiNET.SampleProgram.XNA
         protected virtual void UpdateInput()
         {
             if (!_game.IsActive) return;
-            
+
             var io = ImGui.GetIO();
 
             var mouse = Mouse.GetState();
@@ -202,6 +205,7 @@ namespace ImGuiNET.SampleProgram.XNA
             io.AddMouseButtonEvent(3, mouse.XButton1 == ButtonState.Pressed);
             io.AddMouseButtonEvent(4, mouse.XButton2 == ButtonState.Pressed);
 
+            // FNA-specific information. FNA does not have horizontal scroll wheel support. So you need to set 0f for horizontal scroll wheel value.
             io.AddMouseWheelEvent(
                 (mouse.HorizontalScrollWheelValue - _horizontalScrollWheelValue) / WHEEL_DELTA,
                 (mouse.ScrollWheelValue - _scrollWheelValue) / WHEEL_DELTA);
@@ -220,11 +224,11 @@ namespace ImGuiNET.SampleProgram.XNA
             io.DisplayFramebufferScale = new System.Numerics.Vector2(1f, 1f);
         }
 
-        private bool TryMapKeys(Keys key, out ImGuiKey imguikey)
+        private static bool TryMapKeys(Keys key, out ImGuiKey imguikey)
         {
-            //Special case not handed in the switch...
-            //If the actual key we put in is "None", return none and true. 
-            //otherwise, return none and false.
+            // Special case not handed in the switch...
+            // If the actual key we put in is "None", return none and true. 
+            // otherwise, return none and false.
             if (key == Keys.None)
             {
                 imguikey = ImGuiKey.None;
@@ -390,12 +394,12 @@ namespace ImGuiNET.SampleProgram.XNA
                 {
                     ImDrawCmdPtr drawCmd = cmdList.CmdBuffer[cmdi];
 
-                    if (drawCmd.ElemCount == 0) 
+                    if (drawCmd.ElemCount == 0)
                     {
                         continue;
                     }
 
-                    if (!_loadedTextures.ContainsKey(drawCmd.TextureId))
+                    if (!_loadedTextures.TryGetValue(drawCmd.TextureId, out Texture2D value))
                     {
                         throw new InvalidOperationException($"Could not find a texture with id '{drawCmd.TextureId}', please check your bindings");
                     }
@@ -407,7 +411,7 @@ namespace ImGuiNET.SampleProgram.XNA
                         (int)(drawCmd.ClipRect.W - drawCmd.ClipRect.Y)
                     );
 
-                    var effect = UpdateEffect(_loadedTextures[drawCmd.TextureId]);
+                    var effect = UpdateEffect(value);
 
                     foreach (var pass in effect.CurrentTechnique.Passes)
                     {
@@ -429,6 +433,49 @@ namespace ImGuiNET.SampleProgram.XNA
                 vtxOffset += cmdList.VtxBuffer.Size;
                 idxOffset += cmdList.IdxBuffer.Size;
             }
+        }
+
+        // MonoGame-specific //////////////////////
+        private void OnTextInput(object s, TextInputEventArgs a)
+        {
+           if (a.Character == '\t') return;
+           ImGui.GetIO().AddInputCharacter(a.Character);
+        }
+        ///////////////////////////////////////////
+
+        // FNA-specific ///////////////////////////
+        // private void OnTextInput(char c)
+        // {
+        //     if (c == '\t') return;
+        //     ImGui.GetIO().AddInputCharacter(c);
+        // }
+        /////////////////////////////////////////
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (_disposed) return;
+
+            if (disposing)
+            {
+                _vertexBuffer?.Dispose();
+                _indexBuffer?.Dispose();
+                _effect?.Dispose();
+
+                foreach (var texture in _loadedTextures)
+                {
+                    texture.Value?.Dispose();
+                }
+
+                // MonoGame-specific //////////////////////
+                _game.Window.TextInput -= OnTextInput;
+                ///////////////////////////////////////////
+
+                // FNA-specific ///////////////////////////
+                // TextInputEXT.TextInput -= OnTextInput;
+                /////////////////////////////////////////
+            }
+
+            _disposed = true;
         }
 
         #endregion Internals

--- a/src/ImGui.NET.SampleProgram.XNA/ImGuiRenderer.cs
+++ b/src/ImGui.NET.SampleProgram.XNA/ImGuiRenderer.cs
@@ -40,7 +40,7 @@ namespace ImGuiNET.SampleProgram.XNA
         private readonly float WHEEL_DELTA = 120;
         private readonly Keys[] _allKeys = Enum.GetValues<Keys>();
 
-        private bool _disposed;
+        private bool _isDisposed;
 
         public ImGuiRenderer(Game game)
         {
@@ -453,7 +453,7 @@ namespace ImGuiNET.SampleProgram.XNA
 
         protected virtual void Dispose(bool disposing)
         {
-            if (_disposed) return;
+            if (_isDisposed) return;
 
             if (disposing)
             {
@@ -475,7 +475,7 @@ namespace ImGuiNET.SampleProgram.XNA
                 ///////////////////////////////////////////
             }
 
-            _disposed = true;
+            _isDisposed = true;
         }
 
         #endregion Internals

--- a/src/ImGui.NET.SampleProgram.XNA/ImGuiRenderer.cs
+++ b/src/ImGui.NET.SampleProgram.XNA/ImGuiRenderer.cs
@@ -36,8 +36,8 @@ namespace ImGuiNET.SampleProgram.XNA
 
         // Input
         private int _scrollWheelValue;
-        private int _horizontalScrollWheelValue;
-        private readonly float WHEEL_DELTA = 120;
+        private int _horizontalScrollWheelValue; // FNA does not support horizontal scroll wheel. This can be commented out when using FNA.
+        private const float WHEEL_DELTA = 120;
         private readonly Keys[] _allKeys = Enum.GetValues<Keys>();
 
         private bool _isDisposed;
@@ -171,18 +171,21 @@ namespace ImGuiNET.SampleProgram.XNA
         /// </summary>
         protected virtual Effect UpdateEffect(Texture2D texture)
         {
-            _effect ??= new BasicEffect(_graphicsDevice);
-
             var io = ImGui.GetIO();
 
+            _effect ??= new BasicEffect(_graphicsDevice);
             _effect.World = Matrix.Identity;
             _effect.View = Matrix.Identity;
             _effect.Projection = Matrix.CreateOrthographicOffCenter(0f, io.DisplaySize.X, io.DisplaySize.Y, 0f, -1f, 1f);
             _effect.TextureEnabled = true;
             _effect.Texture = texture;
             _effect.VertexColorEnabled = true;
-            _effect.Name = $"{texture.Name}_effect";
-            _effect.Tag = "ImGui";
+
+            if (string.IsNullOrEmpty(_effect.Name))
+            {
+                _effect.Name = $"{texture.Name}_effect";
+                _effect.Tag = "ImGui";
+            }
 
             return _effect;
         }

--- a/src/ImGui.NET.SampleProgram.XNA/ImGuiRenderer.cs
+++ b/src/ImGui.NET.SampleProgram.XNA/ImGuiRenderer.cs
@@ -21,11 +21,11 @@ namespace ImGuiNET.SampleProgram.XNA
         private readonly RasterizerState _rasterizerState;
 
         private byte[] _vertexData;
-        private VertexBuffer _vertexBuffer;
+        private DynamicVertexBuffer _vertexBuffer;
         private int _vertexBufferSize;
 
         private byte[] _indexData;
-        private IndexBuffer _indexBuffer;
+        private DynamicIndexBuffer _indexBuffer;
         private int _indexBufferSize;
 
         // Textures
@@ -230,7 +230,7 @@ namespace ImGuiNET.SampleProgram.XNA
         private static bool TryMapKeys(Keys key, out ImGuiKey imguikey)
         {
             // Special case not handed in the switch...
-            // If the actual key we put in is "None", return none and true. 
+            // If the actual key we put in is "None", return none and true.
             // otherwise, return none and false.
             if (key == Keys.None)
             {
@@ -344,7 +344,7 @@ namespace ImGuiNET.SampleProgram.XNA
                 _vertexBuffer?.Dispose();
 
                 _vertexBufferSize = (int)(drawData.TotalVtxCount * 1.5f);
-                _vertexBuffer = new VertexBuffer(_graphicsDevice, DrawVertDeclaration.Declaration, _vertexBufferSize, BufferUsage.None);
+                _vertexBuffer = new DynamicVertexBuffer(_graphicsDevice, DrawVertDeclaration.Declaration, _vertexBufferSize, BufferUsage.None);
                 _vertexData = new byte[_vertexBufferSize * DrawVertDeclaration.Size];
             }
 
@@ -353,7 +353,7 @@ namespace ImGuiNET.SampleProgram.XNA
                 _indexBuffer?.Dispose();
 
                 _indexBufferSize = (int)(drawData.TotalIdxCount * 1.5f);
-                _indexBuffer = new IndexBuffer(_graphicsDevice, IndexElementSize.SixteenBits, _indexBufferSize, BufferUsage.None);
+                _indexBuffer = new DynamicIndexBuffer(_graphicsDevice, IndexElementSize.SixteenBits, _indexBufferSize, BufferUsage.None);
                 _indexData = new byte[_indexBufferSize * sizeof(ushort)];
             }
 
@@ -377,8 +377,10 @@ namespace ImGuiNET.SampleProgram.XNA
             }
 
             // Copy the managed byte arrays to the gpu vertex- and index buffers
-            _vertexBuffer.SetData(_vertexData, 0, drawData.TotalVtxCount * DrawVertDeclaration.Size);
-            _indexBuffer.SetData(_indexData, 0, drawData.TotalIdxCount * sizeof(ushort));
+            // Discard means we don't need last frame's data, so the driver can give us
+            // fresh storage instead of stalling until the GPU is done reading it.
+            _vertexBuffer?.SetData(_vertexData, 0, drawData.TotalVtxCount * DrawVertDeclaration.Size, SetDataOptions.Discard);
+            _indexBuffer?.SetData(_indexData, 0, drawData.TotalIdxCount * sizeof(ushort), SetDataOptions.Discard);
         }
 
         private unsafe void RenderCommandLists(ImDrawDataPtr drawData)

--- a/src/ImGui.NET.SampleProgram.XNA/ImGuiRenderer.cs
+++ b/src/ImGui.NET.SampleProgram.XNA/ImGuiRenderer.cs
@@ -449,7 +449,7 @@ namespace ImGuiNET.SampleProgram.XNA
         //     if (c == '\t') return;
         //     ImGui.GetIO().AddInputCharacter(c);
         // }
-        /////////////////////////////////////////
+        ///////////////////////////////////////////
 
         protected virtual void Dispose(bool disposing)
         {
@@ -472,7 +472,7 @@ namespace ImGuiNET.SampleProgram.XNA
 
                 // FNA-specific ///////////////////////////
                 // TextInputEXT.TextInput -= OnTextInput;
-                /////////////////////////////////////////
+                ///////////////////////////////////////////
             }
 
             _disposed = true;

--- a/src/ImGui.NET.SampleProgram.XNA/SampleGame.cs
+++ b/src/ImGui.NET.SampleProgram.XNA/SampleGame.cs
@@ -22,7 +22,7 @@ namespace ImGuiNET.SampleProgram.XNA
             _graphics = new GraphicsDeviceManager(this);
             _graphics.PreferredBackBufferWidth = 1024;
             _graphics.PreferredBackBufferHeight = 768;
-            _graphics.PreferMultiSampling = true;
+            _graphics.PreferMultiSampling = false;
 
             IsMouseVisible = true;
         }

--- a/src/ImGui.NET.SampleProgram.XNA/SampleGame.cs
+++ b/src/ImGui.NET.SampleProgram.XNA/SampleGame.cs
@@ -52,6 +52,13 @@ namespace ImGuiNET.SampleProgram.XNA
             base.LoadContent();
         }
 
+        protected override void UnloadContent()
+        {
+            _imGuiRenderer.Dispose();
+            Content.Unload();
+            base.UnloadContent();
+        }
+
         protected override void Draw(GameTime gameTime)
         {
             GraphicsDevice.Clear(new Color(clear_color.X, clear_color.Y, clear_color.Z));

--- a/src/ImGui.NET.SampleProgram.XNA/SampleGame.cs
+++ b/src/ImGui.NET.SampleProgram.XNA/SampleGame.cs
@@ -63,14 +63,20 @@ namespace ImGuiNET.SampleProgram.XNA
         {
             GraphicsDevice.Clear(new Color(clear_color.X, clear_color.Y, clear_color.Z));
 
-            // Call BeforeLayout first to set things up
-            _imGuiRenderer.BeforeLayout(gameTime);
+            // Only draw the UI when we have a valid delta time. Otherwise ImGui will give an assertion failure.
+            float dt = (float)gameTime.ElapsedGameTime.TotalSeconds;
+            if (dt > 0f)
+            {
+                ImGui.GetIO().Framerate = 1f / dt;
+                // Call BeforeLayout first to set things up
+                _imGuiRenderer.BeforeLayout(gameTime);
 
-            // Draw our UI
-            ImGuiLayout();
+                // Draw our UI
+                ImGuiLayout();
 
-            // Call AfterLayout now to finish up and draw all the things
-            _imGuiRenderer.AfterLayout();
+                // Call AfterLayout now to finish up and draw all the things
+                _imGuiRenderer.AfterLayout();
+            }    
 
             base.Draw(gameTime);
         }


### PR DESCRIPTION
It's good to dispose ImGuiRenderer when unloading content. 
For example if the game use multiple game states which unload and loads content. 

Also if you instantiated ImGuiRenderer again there would be multiple event handlers for text inputs, so I removed those in the Dispose too. 

Enabled docking in BeforeLayout, otherwise you would get an cimgui assert error when you tried to use the docking feature.

Did some minor code cleanups.